### PR TITLE
feat(trt): upgrade C API to OAAX v2 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,16 @@ docker run --rm --gpus all \
 # Output: output/model.trt + output/logs.json
 ```
 
-**2. Run inference** — load `libRuntimeLibrary.so` and use the [OAAX C API](https://github.com/OAAX-standard/OAAX):
+**2. Run inference** — load `libRuntimeLibrary.so` and use the [OAAX v2 C API](https://github.com/OAAX-standard/OAAX):
 ```c
-runtime_initialization(2, (char*[]){"log_level=2", "log_file=runtime.log"});
-runtime_load_model("/path/to/model.trt", model_config_json);
-send_input(tensors);
-receive_output(&out_tensors);
-runtime_destruct();
+Config cfg = {0, NULL, NULL};
+runtime_init(cfg);
+ModelConfig mc = {"/path/to/model.trt", NULL, 0, {0, NULL, NULL}};
+runtime_load_models(1, &mc);
+runtime_enqueue_input(0, input_tensors);
+int model_id; Tensors *out;
+runtime_retrieve_output(&model_id, &out, 5000 /* ms */);
+runtime_cleanup();
 ```
 
 See [`tensorrt/conversion-toolchain/README.md`](tensorrt/conversion-toolchain/README.md) and [`tensorrt/runtime-library/README.md`](tensorrt/runtime-library/README.md) for full details.

--- a/tensorrt/runtime-library/CMakeLists.txt
+++ b/tensorrt/runtime-library/CMakeLists.txt
@@ -139,13 +139,6 @@ FetchContent_Declare(concurrentqueue
     GIT_SHALLOW    TRUE)
 FetchContent_MakeAvailable(concurrentqueue)
 
-# tools repo contains c-utilities as a subdirectory
-FetchContent_Declare(tools
-    GIT_REPOSITORY https://github.com/OAAX-standard/tools
-    GIT_TAG        main
-    GIT_SHALLOW    TRUE
-    SOURCE_SUBDIR  c-utilities)
-FetchContent_MakeAvailable(tools)
 
 # === Library Target ===
 file(GLOB_RECURSE SRC
@@ -192,7 +185,6 @@ target_link_libraries(RuntimeLibrary PUBLIC
     nvinfer_plugin
     cudart
     spdlog::spdlog
-    c_utilities
     stdc++
     -Wl,--end-group)
 

--- a/tensorrt/runtime-library/include/interface.h
+++ b/tensorrt/runtime-library/include/interface.h
@@ -1,0 +1,104 @@
+#ifndef OAAX_RUNTIME_INTERFACE_H
+#define OAAX_RUNTIME_INTERFACE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum RuntimeStatus {
+  RUNTIME_STATUS_SUCCESS = 0,
+  RUNTIME_STATUS_ERROR = 1,
+  RUNTIME_STATUS_NOT_INITIALIZED = 2,
+  RUNTIME_STATUS_ALREADY_INITIALIZED = 3,
+  RUNTIME_STATUS_MODEL_NOT_LOADED = 4,
+  RUNTIME_STATUS_INVALID_ARGUMENT = 5,
+  RUNTIME_STATUS_INVALID_MODEL = 6,
+  RUNTIME_STATUS_FILE_NOT_FOUND = 7,
+  RUNTIME_STATUS_OUT_OF_MEMORY = 8,
+  RUNTIME_STATUS_INVALID_TENSOR = 9,
+  RUNTIME_STATUS_TENSOR_SHAPE_MISMATCH = 10,
+  RUNTIME_STATUS_TENSOR_TYPE_MISMATCH = 11,
+  RUNTIME_STATUS_NO_OUTPUT_AVAILABLE = 12,
+  RUNTIME_STATUS_INFERENCE_ERROR = 13,
+  RUNTIME_STATUS_NOT_IMPLEMENTED = 14,
+  RUNTIME_STATUS_TIMEOUT = 15,
+  RUNTIME_STATUS_DEVICE_ERROR = 16,
+  RUNTIME_STATUS_UNKNOWN_ERROR = 17,
+  RUNTIME_STATUS_INVALID_MODEL_ID = 18
+} RuntimeStatus;
+
+typedef enum TensorElementType {
+  DATA_TYPE_UNDEFINED = 0,
+  DATA_TYPE_FLOAT = 1,
+  DATA_TYPE_UINT8 = 2,
+  DATA_TYPE_INT8 = 3,
+  DATA_TYPE_UINT16 = 4,
+  DATA_TYPE_INT16 = 5,
+  DATA_TYPE_INT32 = 6,
+  DATA_TYPE_INT64 = 7,
+  DATA_TYPE_STRING = 8,
+  DATA_TYPE_BOOL = 9,
+  DATA_TYPE_FLOAT16 = 10,
+  DATA_TYPE_DOUBLE = 11,
+  DATA_TYPE_UINT32 = 12,
+  DATA_TYPE_UINT64 = 13,
+  DATA_TYPE_COMPLEX64 = 14,
+  DATA_TYPE_COMPLEX128 = 15,
+  DATA_TYPE_BFLOAT16 = 16,
+  DATA_TYPE_FLOAT8E4M3FN = 17,
+  DATA_TYPE_FLOAT8E4M3FNUZ = 18,
+  DATA_TYPE_FLOAT8E5M2 = 19,
+  DATA_TYPE_FLOAT8E5M2FNUZ = 20,
+  DATA_TYPE_UINT4 = 21,
+  DATA_TYPE_INT4 = 22,
+  DATA_TYPE_FLOAT4E2M1 = 23,
+  DATA_TYPE_FLOAT8E8M0 = 24,
+  DATA_TYPE_UINT2 = 25,
+  DATA_TYPE_INT2 = 26
+} TensorElementType;
+
+typedef struct TensorDescriptor {
+  char              *name;
+  TensorElementType  data_type;
+  int                rank;
+  int               *shape;
+  size_t             data_size;
+  void              *data;
+} TensorDescriptor;
+
+typedef struct Tensors {
+  int               id;
+  int               num_tensors;
+  TensorDescriptor *tensors;
+} Tensors;
+
+typedef struct Config {
+  int          length;
+  const char **keys;
+  const char **values;
+} Config;
+
+typedef struct ModelConfig {
+  const char *file_path;
+  const unsigned char *model_data;
+  size_t model_size;
+  Config config;
+} ModelConfig;
+
+RuntimeStatus runtime_init(Config config);
+RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs);
+RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors);
+RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms);
+RuntimeStatus runtime_cleanup(void);
+const char *runtime_get_error(void);
+const char *runtime_get_version(void);
+const char *runtime_get_name(void);
+const char *runtime_get_info(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OAAX_RUNTIME_INTERFACE_H

--- a/tensorrt/runtime-library/include/runtime_core.hpp
+++ b/tensorrt/runtime-library/include/runtime_core.hpp
@@ -1,28 +1,18 @@
 #ifndef RUNTIME_CORE_HPP
 #define RUNTIME_CORE_HPP
 
-extern "C" {
-#include "tensors_struct.h"
-}
+#include "interface.h"
 
 #define EXPOSE_FUNCTION __attribute__((visibility("default")))
 
-extern "C" EXPOSE_FUNCTION int runtime_initialization_with_args(int length, char **keys, void **values);
-
-extern "C" EXPOSE_FUNCTION int runtime_initialization();
-
-extern "C" EXPOSE_FUNCTION int runtime_model_loading(const char *model_path);
-
-extern "C" EXPOSE_FUNCTION int send_input(tensors_struct *input_tensors);
-
-extern "C" EXPOSE_FUNCTION int receive_output(tensors_struct **output_tensors);
-
-extern "C" EXPOSE_FUNCTION int runtime_destruction();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_error_message();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_version();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_name();
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_init(Config config);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_cleanup(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_error(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_version(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_name(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_info(void);
 
 #endif // RUNTIME_CORE_HPP

--- a/tensorrt/runtime-library/include/runtime_utils.hpp
+++ b/tensorrt/runtime-library/include/runtime_utils.hpp
@@ -10,22 +10,15 @@
 
 using namespace std;
 
-// Map a TensorRT DataType to the OAAX tensor_data_type enum
-tensor_data_type map_trt_to_oaax_type(nvinfer1::DataType dtype);
-
-// Return the byte size of a single element for a TensorRT DataType
+TensorElementType map_trt_to_oaax_type(nvinfer1::DataType dtype);
 size_t trt_dtype_byte_size(nvinfer1::DataType dtype);
-
-// Compute total byte size of a tensor given its dims and dtype
 size_t compute_tensor_byte_size(const nvinfer1::Dims &dims, nvinfer1::DataType dtype);
-
+void deep_free_tensors(Tensors *t);
+void free_queue(moodycamel::ConcurrentQueue<Tensors *> &queue);
 shared_ptr<spdlog::logger> initialize_logger(const string &log_file,
-                                             int file_level = spdlog::level::info,
-                                             int console_level = spdlog::level::info,
-                                             const string prefix = "OAAX");
-
+                                              int file_level,
+                                              int console_level,
+                                              const string prefix);
 void destroy_logger(shared_ptr<spdlog::logger> logger);
-
-void free_queue(moodycamel::ConcurrentQueue<tensors_struct *> &queue);
 
 #endif // RUNTIME_UTILS_HPP

--- a/tensorrt/runtime-library/src/runtime_core.cpp
+++ b/tensorrt/runtime-library/src/runtime_core.cpp
@@ -1,4 +1,5 @@
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <fstream>
 #include <stdexcept>
@@ -11,397 +12,350 @@
 #include "concurrentqueue.h"
 #include <spdlog/spdlog.h>
 
-#include "runtime_core.hpp"   // pulls in tensors_struct.h with extern "C"
+#include "runtime_core.hpp"
 #include "runtime_utils.hpp"
 
 using namespace std;
 
-// Forward declaration
-static void inference_thread_func();
-
-// TRT logger: forwards TRT messages to spdlog
-class TrtLogger : public nvinfer1::ILogger
-{
+// TRT ILogger forwarding to spdlog
+class TrtLogger : public nvinfer1::ILogger {
 public:
-    void log(Severity severity, const char *msg) noexcept override;
+    void log(Severity sev, const char *msg) noexcept override;
 };
 static TrtLogger trt_logger;
 
-// TRT objects
-static nvinfer1::IRuntime *trt_runtime = nullptr;
-static nvinfer1::ICudaEngine *engine = nullptr;
-static nvinfer1::IExecutionContext *context = nullptr;
-static cudaStream_t infer_stream = nullptr;
-
-// Per-tensor info populated at model load time
+// Per-tensor info for one model
 struct TensorInfo {
-    std::string name;
+    string name;
     bool is_input;
     nvinfer1::Dims dims;
     nvinfer1::DataType dtype;
     size_t byte_size;
     void *gpu_buf = nullptr;
 };
-static std::vector<TensorInfo> tensor_infos;
-static std::vector<size_t> input_indices;   // indices into tensor_infos
-static std::vector<size_t> output_indices;  // indices into tensor_infos
 
-// Input/output queues
-static moodycamel::ConcurrentQueue<tensors_struct *> input_tensors_queue;
-static moodycamel::ConcurrentQueue<tensors_struct *> output_tensors_queue;
+// Per-model runtime state
+struct ModelState {
+    int model_id;
+    nvinfer1::ICudaEngine *engine = nullptr;
+    nvinfer1::IExecutionContext *context = nullptr;
+    cudaStream_t stream = nullptr;
+    vector<TensorInfo> tensor_infos;
+    vector<size_t> input_indices;
+    vector<size_t> output_indices;
+    moodycamel::ConcurrentQueue<Tensors *> input_queue;
+    thread inference_thread;
+    atomic<bool> stop{false};
+};
 
-// Inference thread
-static std::thread inference_thread;
-static std::atomic<bool> stop_inference_thread{false};
+static bool initialized = false;
+static string last_error_msg;
+static int log_level_val = spdlog::level::info;
+static string log_file_val = "runtime.log";
 
-// Logger and runtime config
-std::shared_ptr<spdlog::logger> logger;
-static int log_level = spdlog::level::info;
-static std::string log_file = "runtime.log";
+static nvinfer1::IRuntime *trt_runtime = nullptr;
+static vector<unique_ptr<ModelState>> model_states;
+static moodycamel::ConcurrentQueue<Tensors *> output_queue;
 
-// TrtLogger implementation
-void TrtLogger::log(Severity severity, const char *msg) noexcept
-{
-    if (!logger)
-        return;
-    switch (severity)
-    {
+shared_ptr<spdlog::logger> logger;
+
+static void set_error(const string &msg) {
+    last_error_msg = msg;
+    if (logger) logger->error("{}", msg);
+}
+
+void TrtLogger::log(Severity sev, const char *msg) noexcept {
+    if (!logger) return;
+    switch (sev) {
     case Severity::kINTERNAL_ERROR:
-    case Severity::kERROR:
-        logger->error("[TRT] {}", msg);
-        break;
-    case Severity::kWARNING:
-        logger->warn("[TRT] {}", msg);
-        break;
-    case Severity::kINFO:
-        logger->info("[TRT] {}", msg);
-        break;
-    case Severity::kVERBOSE:
-        logger->trace("[TRT] {}", msg);
-        break;
+    case Severity::kERROR:   logger->error("[TRT] {}", msg); break;
+    case Severity::kWARNING: logger->warn("[TRT] {}", msg);  break;
+    case Severity::kINFO:    logger->info("[TRT] {}", msg);  break;
+    case Severity::kVERBOSE: logger->trace("[TRT] {}", msg); break;
     }
 }
 
-extern "C" int runtime_initialization_with_args(int length, char **keys, void **values)
-{
-    for (int i = 0; i < length; ++i)
-    {
-        std::string key(keys[i]);
-        if (key == "log_level")
-        {
-            int value = std::stoi(static_cast<char *>(values[i]));
-            log_level = (value >= spdlog::level::trace && value <= spdlog::level::off)
-                            ? value
-                            : spdlog::level::info;
-        }
-        else if (key == "log_file")
-        {
-            log_file = std::string(static_cast<char *>(values[i]));
-        }
-    }
-    return runtime_initialization();
+static void destroy_model_state(ModelState *ms) {
+    if (!ms) return;
+    ms->stop = true;
+    if (ms->inference_thread.joinable()) ms->inference_thread.join();
+    free_queue(ms->input_queue);
+    for (auto &ti : ms->tensor_infos)
+        if (ti.gpu_buf) { cudaFree(ti.gpu_buf); ti.gpu_buf = nullptr; }
+    if (ms->stream)  { cudaStreamDestroy(ms->stream); ms->stream = nullptr; }
+    if (ms->context) { delete ms->context; ms->context = nullptr; }
+    if (ms->engine)  { delete ms->engine;  ms->engine  = nullptr; }
 }
 
-extern "C" int runtime_initialization()
+static void inference_thread_func(ModelState *ms)
 {
-    try
-    {
-        logger = initialize_logger(log_file, log_level, log_level, runtime_name());
-        logger->info("Initializing TensorRT runtime");
-
-        trt_runtime = nvinfer1::createInferRuntime(trt_logger);
-        if (!trt_runtime)
-            throw std::runtime_error("Failed to create TRT IRuntime");
-
-        stop_inference_thread = false;
-        inference_thread = std::thread(inference_thread_func);
-
-        logger->info("Inference thread started");
-        logger->info("Runtime arguments: log_level={}, log_file={}", log_level, log_file);
-        return 0;
-    }
-    catch (const std::exception &e)
-    {
-        if (logger)
-            logger->error("Initialization failed: {}", e.what());
-        return -1;
-    }
-}
-
-extern "C" int runtime_model_loading(const char *model_path)
-{
-    logger->info("Loading TRT engine from: {}", model_path);
-    try
-    {
-        // Read engine file into memory
-        std::ifstream file(model_path, std::ios::binary | std::ios::ate);
-        if (!file.is_open())
-            throw std::runtime_error(std::string("Cannot open engine file: ") + model_path);
-        size_t file_size = static_cast<size_t>(file.tellg());
-        file.seekg(0, std::ios::beg);
-        std::vector<char> engine_data(file_size);
-        file.read(engine_data.data(), static_cast<std::streamsize>(file_size));
-        file.close();
-
-        // Deserialize the engine
-        engine = trt_runtime->deserializeCudaEngine(engine_data.data(), file_size);
-        if (!engine)
-            throw std::runtime_error("Failed to deserialize TRT engine");
-
-        context = engine->createExecutionContext();
-        if (!context)
-            throw std::runtime_error("Failed to create TRT execution context");
-
-        if (cudaStreamCreate(&infer_stream) != cudaSuccess)
-            throw std::runtime_error("Failed to create CUDA stream");
-
-        // Build tensor info and allocate persistent GPU buffers
-        int nb_tensors = engine->getNbIOTensors();
-        tensor_infos.clear();
-        input_indices.clear();
-        output_indices.clear();
-        tensor_infos.resize(static_cast<size_t>(nb_tensors));
-
-        for (int i = 0; i < nb_tensors; ++i)
-        {
-            const char *name = engine->getIOTensorName(i);
-            TensorInfo &ti = tensor_infos[static_cast<size_t>(i)];
-            ti.name = name;
-            ti.is_input = (engine->getTensorIOMode(name) == nvinfer1::TensorIOMode::kINPUT);
-            ti.dims = engine->getTensorShape(name);
-            ti.dtype = engine->getTensorDataType(name);
-            ti.byte_size = compute_tensor_byte_size(ti.dims, ti.dtype);
-
-            if (cudaMalloc(&ti.gpu_buf, ti.byte_size) != cudaSuccess)
-                throw std::runtime_error(std::string("cudaMalloc failed for tensor: ") + name);
-
-            if (ti.is_input)
-                input_indices.push_back(static_cast<size_t>(i));
-            else
-                output_indices.push_back(static_cast<size_t>(i));
-
-            logger->info("  Tensor {}: name={} {} dtype={} byte_size={}",
-                         i, name,
-                         ti.is_input ? "INPUT" : "OUTPUT",
-                         static_cast<int>(ti.dtype),
-                         ti.byte_size);
-        }
-
-        logger->info("Engine loaded: {} inputs, {} outputs",
-                     input_indices.size(), output_indices.size());
-        return 0;
-    }
-    catch (const std::exception &e)
-    {
-        logger->error("Model loading failed: {}", e.what());
-        return -1;
-    }
-}
-
-extern "C" int send_input(tensors_struct *input_tensors)
-{
-    logger->debug("Enqueuing input. Queue size: ~{}", input_tensors_queue.size_approx());
-    if (!input_tensors_queue.try_enqueue(input_tensors))
-    {
-        logger->warn("Failed to enqueue input tensors");
-        return -1;
-    }
-    logger->trace("Input enqueued");
-    return 0;
-}
-
-static void inference_thread_func()
-{
-    while (!stop_inference_thread)
-    {
-        tensors_struct *input_tensors = nullptr;
-        if (!input_tensors_queue.try_dequeue(input_tensors))
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    while (!ms->stop) {
+        Tensors *input = nullptr;
+        if (!ms->input_queue.try_dequeue(input)) {
+            this_thread::sleep_for(chrono::milliseconds(5));
             continue;
         }
-        logger->debug("Dequeued input, running inference");
+        logger->debug("Model {}: dequeued input id={}", ms->model_id, input->id);
 
-        // Pre-allocate host output buffers so we can pipeline D2H with inference
-        std::vector<void *> host_out_bufs(output_indices.size(), nullptr);
+        vector<void *> host_out_bufs(ms->output_indices.size(), nullptr);
+        int req_id = input->id;
 
-        try
-        {
-            if (input_tensors->num_tensors != input_indices.size())
-                throw std::runtime_error("Input tensor count mismatch with engine");
+        try {
+            if ((size_t)input->num_tensors != ms->input_indices.size())
+                throw runtime_error("Input tensor count mismatch");
 
-            // Allocate host output buffers (needed before enqueuing D2H copies)
-            for (size_t i = 0; i < output_indices.size(); ++i)
-            {
-                host_out_bufs[i] = malloc(tensor_infos[output_indices[i]].byte_size);
-                if (!host_out_bufs[i])
-                    throw std::runtime_error("malloc failed for output buffer");
+            for (size_t i = 0; i < ms->output_indices.size(); ++i) {
+                host_out_bufs[i] = malloc(ms->tensor_infos[ms->output_indices[i]].byte_size);
+                if (!host_out_bufs[i]) throw runtime_error("malloc failed for output buffer");
             }
 
-            // H2D: copy inputs to GPU (async, queued on infer_stream)
-            for (size_t i = 0; i < input_indices.size(); ++i)
-            {
-                TensorInfo &ti = tensor_infos[input_indices[i]];
-                if (cudaMemcpyAsync(ti.gpu_buf, input_tensors->data[i], ti.byte_size,
-                                    cudaMemcpyHostToDevice, infer_stream) != cudaSuccess)
-                    throw std::runtime_error("cudaMemcpyAsync H2D failed");
+            for (size_t i = 0; i < ms->input_indices.size(); ++i) {
+                TensorInfo &ti = ms->tensor_infos[ms->input_indices[i]];
+                if (cudaMemcpyAsync(ti.gpu_buf, input->tensors[i].data, ti.byte_size,
+                                    cudaMemcpyHostToDevice, ms->stream) != cudaSuccess)
+                    throw runtime_error("cudaMemcpyAsync H2D failed");
             }
 
-            // Bind all tensor addresses (inputs and outputs)
-            for (auto &ti : tensor_infos)
-                context->setTensorAddress(ti.name.c_str(), ti.gpu_buf);
+            for (auto &ti : ms->tensor_infos)
+                ms->context->setTensorAddress(ti.name.c_str(), ti.gpu_buf);
 
-            // Enqueue inference
-            if (!context->enqueueV3(infer_stream))
-                throw std::runtime_error("TRT enqueueV3 failed");
+            if (!ms->context->enqueueV3(ms->stream))
+                throw runtime_error("TRT enqueueV3 failed");
 
-            // D2H: copy outputs from GPU (async, queued after inference on same stream)
-            for (size_t i = 0; i < output_indices.size(); ++i)
-            {
-                TensorInfo &ti = tensor_infos[output_indices[i]];
+            for (size_t i = 0; i < ms->output_indices.size(); ++i) {
+                TensorInfo &ti = ms->tensor_infos[ms->output_indices[i]];
                 if (cudaMemcpyAsync(host_out_bufs[i], ti.gpu_buf, ti.byte_size,
-                                    cudaMemcpyDeviceToHost, infer_stream) != cudaSuccess)
-                    throw std::runtime_error("cudaMemcpyAsync D2H failed");
+                                    cudaMemcpyDeviceToHost, ms->stream) != cudaSuccess)
+                    throw runtime_error("cudaMemcpyAsync D2H failed");
             }
 
-            // Wait for the full pipeline (H2D + inference + D2H) to complete
-            if (cudaStreamSynchronize(infer_stream) != cudaSuccess)
-                throw std::runtime_error("cudaStreamSynchronize failed");
+            if (cudaStreamSynchronize(ms->stream) != cudaSuccess)
+                throw runtime_error("cudaStreamSynchronize failed");
 
-            deep_free_tensors_struct(input_tensors);
-            input_tensors = nullptr;
+            deep_free_tensors(input);
+            input = nullptr;
 
-            // Build output tensors_struct; host_out_bufs[i] ownership transferred
-            size_t n_out = output_indices.size();
-            tensors_struct *output_tensors =
-                static_cast<tensors_struct *>(malloc(sizeof(tensors_struct)));
-            output_tensors->num_tensors = n_out;
-            output_tensors->names      = static_cast<char **>(malloc(sizeof(char *) * n_out));
-            output_tensors->data_types = static_cast<tensor_data_type *>(
-                malloc(sizeof(tensor_data_type) * n_out));
-            output_tensors->ranks      = static_cast<size_t *>(malloc(sizeof(size_t) * n_out));
-            output_tensors->shapes     = static_cast<size_t **>(malloc(sizeof(size_t *) * n_out));
-            output_tensors->data       = static_cast<void **>(malloc(sizeof(void *) * n_out));
+            size_t n_out = ms->output_indices.size();
+            Tensors *out = (Tensors *)malloc(sizeof(Tensors));
+            out->id = req_id;
+            out->num_tensors = (int)n_out;
+            out->tensors = (TensorDescriptor *)malloc(n_out * sizeof(TensorDescriptor));
 
-            for (size_t i = 0; i < output_indices.size(); ++i)
-            {
-                TensorInfo &ti = tensor_infos[output_indices[i]];
+            for (size_t i = 0; i < n_out; ++i) {
+                TensorInfo &ti = ms->tensor_infos[ms->output_indices[i]];
+                TensorDescriptor &td = out->tensors[i];
 
-                output_tensors->names[i] = static_cast<char *>(malloc(ti.name.size() + 1));
-                strcpy(output_tensors->names[i], ti.name.c_str());
+                td.name = strdup(ti.name.c_str());
 
-                output_tensors->data_types[i] = map_trt_to_oaax_type(ti.dtype);
+                td.data_type = map_trt_to_oaax_type(ti.dtype);
+                td.rank = ti.dims.nbDims;
+                td.shape = (int *)malloc(td.rank * sizeof(int));
+                for (int d = 0; d < td.rank; ++d)
+                    td.shape[d] = (int)ti.dims.d[d];
 
-                output_tensors->ranks[i] = static_cast<size_t>(ti.dims.nbDims);
-                output_tensors->shapes[i] = static_cast<size_t *>(
-                    malloc(sizeof(size_t) * static_cast<size_t>(ti.dims.nbDims)));
-                for (int d = 0; d < ti.dims.nbDims; ++d)
-                    output_tensors->shapes[i][static_cast<size_t>(d)] =
-                        static_cast<size_t>(ti.dims.d[d]);
-
-                output_tensors->data[i] = host_out_bufs[i]; // transfer ownership
+                td.data_size = ti.byte_size;
+                td.data = host_out_bufs[i];
                 host_out_bufs[i] = nullptr;
             }
 
-            if (!output_tensors_queue.try_enqueue(output_tensors))
-            {
-                logger->error("Failed to enqueue output tensors");
-                deep_free_tensors_struct(output_tensors);
+            if (!output_queue.try_enqueue(out)) {
+                logger->error("Failed to enqueue output");
+                deep_free_tensors(out);
             }
-            else
-            {
-                logger->debug("Output enqueued");
-            }
-        }
-        catch (const std::exception &e)
-        {
+        } catch (const exception &e) {
+            if (input) deep_free_tensors(input);
+            for (void *buf : host_out_bufs) free(buf);
             logger->error("Inference error: {}", e.what());
-            if (input_tensors)
-                deep_free_tensors_struct(input_tensors);
-            for (void *buf : host_out_bufs)
-                free(buf);
         }
     }
 }
 
-extern "C" int receive_output(tensors_struct **output_tensors)
+extern "C" RuntimeStatus runtime_init(Config config)
 {
-    logger->debug("Checking for output. Queue size: ~{}", output_tensors_queue.size_approx());
-    if (output_tensors_queue.size_approx() == 0)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        return -1;
+    if (initialized) {
+        set_error("Runtime already initialized");
+        return RUNTIME_STATUS_ALREADY_INITIALIZED;
     }
-    if (!output_tensors_queue.try_dequeue(*output_tensors))
-    {
-        logger->error("Failed to dequeue output tensors");
-        return -1;
+
+    for (int i = 0; i < config.length; ++i) {
+        string key = config.keys[i];
+        string val = config.values[i];
+        if (key == "log_level") {
+            int v = stoi(val);
+            log_level_val = (v >= spdlog::level::trace && v <= spdlog::level::off) ? v : spdlog::level::info;
+        } else if (key == "log_file") {
+            log_file_val = val;
+        }
     }
-    logger->debug("Output received");
-    return 0;
+
+    try {
+        logger = initialize_logger(log_file_val, log_level_val, log_level_val, runtime_get_name());
+        logger->info("Initializing TensorRT runtime");
+        trt_runtime = nvinfer1::createInferRuntime(trt_logger);
+        if (!trt_runtime) throw runtime_error("Failed to create TRT IRuntime");
+        initialized = true;
+        logger->info("Runtime initialized (log_level={})", log_level_val);
+        return RUNTIME_STATUS_SUCCESS;
+    } catch (const exception &e) {
+        set_error(string("runtime_init failed: ") + e.what());
+        return RUNTIME_STATUS_ERROR;
+    }
 }
 
-extern "C" int runtime_destruction()
+extern "C" RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs)
 {
-    logger->info("Destroying runtime...");
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (num_models <= 0 || !model_configs) return RUNTIME_STATUS_INVALID_ARGUMENT;
 
-    stop_inference_thread = true;
-    if (inference_thread.joinable())
-        inference_thread.join();
-    logger->trace("Inference thread stopped");
+    for (auto &ms : model_states) destroy_model_state(ms.get());
+    model_states.clear();
+    free_queue(output_queue);
 
-    free_queue(input_tensors_queue);
-    free_queue(output_tensors_queue);
+    try {
+        for (int i = 0; i < num_models; ++i) {
+            const ModelConfig &mc = model_configs[i];
+            auto ms = make_unique<ModelState>();
+            ms->model_id = i;
 
-    // Free persistent GPU buffers
-    for (auto &ti : tensor_infos)
-    {
-        if (ti.gpu_buf)
-            cudaFree(ti.gpu_buf);
+            vector<char> engine_data;
+            if (mc.file_path) {
+                ifstream file(mc.file_path, ios::binary | ios::ate);
+                if (!file.is_open()) {
+                    set_error(string("Cannot open engine file: ") + mc.file_path);
+                    for (auto &s : model_states) destroy_model_state(s.get());
+                    model_states.clear();
+                    return RUNTIME_STATUS_FILE_NOT_FOUND;
+                }
+                size_t sz = (size_t)file.tellg();
+                file.seekg(0, ios::beg);
+                engine_data.resize(sz);
+                file.read(engine_data.data(), (streamsize)sz);
+                ms->engine = trt_runtime->deserializeCudaEngine(engine_data.data(), sz);
+            } else if (mc.model_data && mc.model_size > 0) {
+                ms->engine = trt_runtime->deserializeCudaEngine(mc.model_data, mc.model_size);
+            } else {
+                set_error("ModelConfig must have file_path or model_data");
+                for (auto &s : model_states) destroy_model_state(s.get());
+                model_states.clear();
+                return RUNTIME_STATUS_INVALID_ARGUMENT;
+            }
+
+            if (!ms->engine) throw runtime_error("Failed to deserialize TRT engine");
+            ms->context = ms->engine->createExecutionContext();
+            if (!ms->context) throw runtime_error("Failed to create execution context");
+            if (cudaStreamCreate(&ms->stream) != cudaSuccess) throw runtime_error("cudaStreamCreate failed");
+
+            int nb = ms->engine->getNbIOTensors();
+            ms->tensor_infos.resize((size_t)nb);
+            for (int j = 0; j < nb; ++j) {
+                const char *name = ms->engine->getIOTensorName(j);
+                TensorInfo &ti = ms->tensor_infos[(size_t)j];
+                ti.name = name;
+                ti.is_input = (ms->engine->getTensorIOMode(name) == nvinfer1::TensorIOMode::kINPUT);
+                ti.dims = ms->engine->getTensorShape(name);
+                ti.dtype = ms->engine->getTensorDataType(name);
+                ti.byte_size = compute_tensor_byte_size(ti.dims, ti.dtype);
+                if (cudaMalloc(&ti.gpu_buf, ti.byte_size) != cudaSuccess)
+                    throw runtime_error(string("cudaMalloc failed for tensor: ") + name);
+                if (ti.is_input)
+                    ms->input_indices.push_back((size_t)j);
+                else
+                    ms->output_indices.push_back((size_t)j);
+            }
+
+            logger->info("Model {}: {} inputs, {} outputs", i, ms->input_indices.size(), ms->output_indices.size());
+            ms->inference_thread = thread(inference_thread_func, ms.get());
+            model_states.push_back(move(ms));
+        }
+        return RUNTIME_STATUS_SUCCESS;
+    } catch (const exception &e) {
+        for (auto &ms : model_states) destroy_model_state(ms.get());
+        model_states.clear();
+        set_error(string("runtime_load_models failed: ") + e.what());
+        return RUNTIME_STATUS_ERROR;
     }
-    tensor_infos.clear();
-    input_indices.clear();
-    output_indices.clear();
-
-    if (infer_stream)
-    {
-        cudaStreamDestroy(infer_stream);
-        infer_stream = nullptr;
-    }
-
-    // TRT objects must be destroyed in reverse creation order
-    if (context)
-    {
-        delete context;
-        context = nullptr;
-    }
-    if (engine)
-    {
-        delete engine;
-        engine = nullptr;
-    }
-    if (trt_runtime)
-    {
-        delete trt_runtime;
-        trt_runtime = nullptr;
-    }
-
-    logger->debug("Runtime destroyed");
-    destroy_logger(logger);
-    return 0;
 }
 
-extern "C" const char *runtime_error_message()
+extern "C" RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors)
 {
-    return "Check the stdout and/or log files for any error message.";
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (model_id < 0 || (size_t)model_id >= model_states.size()) return RUNTIME_STATUS_INVALID_MODEL_ID;
+    if (!input_tensors) return RUNTIME_STATUS_INVALID_ARGUMENT;
+
+    input_tensors->id = model_id;
+
+    if (!model_states[(size_t)model_id]->input_queue.try_enqueue(input_tensors)) {
+        set_error("Failed to enqueue input tensors");
+        return RUNTIME_STATUS_ERROR;
+    }
+    return RUNTIME_STATUS_SUCCESS;
 }
 
-extern "C" const char *runtime_version()
+extern "C" RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms)
+{
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (!model_id || !output_tensors) return RUNTIME_STATUS_INVALID_ARGUMENT;
+
+    if (timeout_ms == 0) {
+        if (!output_queue.try_dequeue(*output_tensors))
+            return RUNTIME_STATUS_NO_OUTPUT_AVAILABLE;
+        *model_id = (*output_tensors)->id;
+        return RUNTIME_STATUS_SUCCESS;
+    }
+
+    auto start = chrono::steady_clock::now();
+    while (true) {
+        if (output_queue.try_dequeue(*output_tensors)) {
+            *model_id = (*output_tensors)->id;
+            return RUNTIME_STATUS_SUCCESS;
+        }
+        if (timeout_ms > 0) {
+            auto elapsed = chrono::duration_cast<chrono::milliseconds>(
+                chrono::steady_clock::now() - start).count();
+            if (elapsed >= timeout_ms)
+                return RUNTIME_STATUS_NO_OUTPUT_AVAILABLE;
+        }
+        this_thread::sleep_for(chrono::milliseconds(1));
+    }
+}
+
+extern "C" RuntimeStatus runtime_cleanup(void)
+{
+    for (auto &ms : model_states) destroy_model_state(ms.get());
+    model_states.clear();
+    free_queue(output_queue);
+    if (trt_runtime) { delete trt_runtime; trt_runtime = nullptr; }
+    initialized = false;
+    last_error_msg.clear();
+    if (logger) {
+        logger->info("Runtime cleaned up");
+        destroy_logger(logger);
+        logger = nullptr;
+    }
+    return RUNTIME_STATUS_SUCCESS;
+}
+
+extern "C" const char *runtime_get_error(void)
+{
+    return last_error_msg.empty() ? nullptr : last_error_msg.c_str();
+}
+
+extern "C" const char *runtime_get_version(void)
 {
     return RUNTIME_VERSION;
 }
 
-extern "C" const char *runtime_name()
+extern "C" const char *runtime_get_name(void)
 {
-    return "OAAX NVIDIA TensorRT Runtime";
+    return "OAAX NVIDIA TensorRT";
+}
+
+extern "C" const char *runtime_get_info(void)
+{
+    if (!initialized) return nullptr;
+    static char buf[256];
+    snprintf(buf, sizeof(buf),
+             "{\"loaded_models\":%zu,\"requests_in_flight\":%zu}",
+             model_states.size(), output_queue.size_approx());
+    return buf;
 }

--- a/tensorrt/runtime-library/src/runtime_utils.cpp
+++ b/tensorrt/runtime-library/src/runtime_utils.cpp
@@ -8,10 +8,28 @@
 
 using namespace std;
 
-tensor_data_type map_trt_to_oaax_type(nvinfer1::DataType dtype)
+void deep_free_tensors(Tensors *t)
 {
-    switch (dtype)
-    {
+    if (!t) return;
+    for (int i = 0; i < t->num_tensors; ++i) {
+        free(t->tensors[i].name);
+        free(t->tensors[i].shape);
+        free(t->tensors[i].data);
+    }
+    free(t->tensors);
+    free(t);
+}
+
+void free_queue(moodycamel::ConcurrentQueue<Tensors *> &queue)
+{
+    Tensors *t;
+    while (queue.try_dequeue(t))
+        deep_free_tensors(t);
+}
+
+TensorElementType map_trt_to_oaax_type(nvinfer1::DataType dtype)
+{
+    switch (dtype) {
     case nvinfer1::DataType::kFLOAT:  return DATA_TYPE_FLOAT;
     case nvinfer1::DataType::kHALF:   return DATA_TYPE_FLOAT16;
     case nvinfer1::DataType::kBF16:   return DATA_TYPE_BFLOAT16;
@@ -21,14 +39,13 @@ tensor_data_type map_trt_to_oaax_type(nvinfer1::DataType dtype)
     case nvinfer1::DataType::kINT64:  return DATA_TYPE_INT64;
     case nvinfer1::DataType::kBOOL:   return DATA_TYPE_BOOL;
     default:
-        throw std::runtime_error("Unsupported TensorRT data type");
+        throw runtime_error("Unsupported TensorRT data type");
     }
 }
 
 size_t trt_dtype_byte_size(nvinfer1::DataType dtype)
 {
-    switch (dtype)
-    {
+    switch (dtype) {
     case nvinfer1::DataType::kFLOAT:  return 4;
     case nvinfer1::DataType::kHALF:   return 2;
     case nvinfer1::DataType::kBF16:   return 2;
@@ -38,7 +55,7 @@ size_t trt_dtype_byte_size(nvinfer1::DataType dtype)
     case nvinfer1::DataType::kINT64:  return 8;
     case nvinfer1::DataType::kBOOL:   return 1;
     default:
-        throw std::runtime_error("Unsupported TensorRT data type");
+        throw runtime_error("Unsupported TensorRT data type");
     }
 }
 
@@ -46,57 +63,42 @@ size_t compute_tensor_byte_size(const nvinfer1::Dims &dims, nvinfer1::DataType d
 {
     size_t count = 1;
     for (int i = 0; i < dims.nbDims; ++i)
-        count *= static_cast<size_t>(dims.d[i]);
+        count *= (size_t)dims.d[i];
     return count * trt_dtype_byte_size(dtype);
 }
 
-void free_queue(moodycamel::ConcurrentQueue<tensors_struct *> &queue)
-{
-    tensors_struct *tensor;
-    while (queue.try_dequeue(tensor))
-        deep_free_tensors_struct(tensor);
-}
-
 shared_ptr<spdlog::logger> initialize_logger(const string &log_file,
-                                             int file_level,
-                                             int console_level,
-                                             const string prefix)
+                                              int file_level,
+                                              int console_level,
+                                              const string prefix)
 {
-    try
-    {
+    try {
         auto console_sink = make_shared<spdlog::sinks::stdout_color_sink_mt>();
         console_sink->set_level(static_cast<spdlog::level::level_enum>(console_level));
 
         auto file_sink = make_shared<spdlog::sinks::rotating_file_sink_st>(
-            log_file, 1024 * 1024 * 5, 3); // 5 MB, 3 rotated files
+            log_file, 1024 * 1024 * 5, 3);
         file_sink->set_level(static_cast<spdlog::level::level_enum>(file_level));
 
         static auto thread_pool = make_shared<spdlog::details::thread_pool>(8192, 1);
-
         auto logger = make_shared<spdlog::async_logger>(
             prefix, spdlog::sinks_init_list{console_sink, file_sink},
             thread_pool, spdlog::async_overflow_policy::overrun_oldest);
 
         spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [" + prefix + "] [%^%l%$] %v");
-        logger->set_level(static_cast<spdlog::level::level_enum>(
-            std::min(file_level, console_level)));
+        logger->set_level(static_cast<spdlog::level::level_enum>(min(file_level, console_level)));
         logger->flush_on(spdlog::level::info);
-
         return logger;
-    }
-    catch (const spdlog::spdlog_ex &ex)
-    {
-        cerr << "Logger initialization failed: " << ex.what() << "\n";
+    } catch (const spdlog::spdlog_ex &ex) {
+        cerr << "Logger init failed: " << ex.what() << "\n";
         exit(EXIT_FAILURE);
     }
 }
 
 void destroy_logger(shared_ptr<spdlog::logger> logger)
 {
-    if (logger)
-    {
+    if (logger) {
         logger->flush();
         spdlog::drop(logger->name());
-        logger = nullptr;
     }
 }

--- a/tensorrt/runtime-library/test/test_runtime.c
+++ b/tensorrt/runtime-library/test/test_runtime.c
@@ -1,144 +1,117 @@
 /*
- * Minimal test for the TensorRT-native runtime library.
- * Tests load → send_input → receive_output with SqueezeNet (1,3,224,224).
+ * Minimal test for the TensorRT-native runtime library (OAAX v2 API).
+ * Tests init → load_models → enqueue_input → retrieve_output with SqueezeNet (1,3,224,224).
  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
-/* OAAX tensors_struct (must match the definition in c_utilities) */
-typedef enum {
-    DATA_TYPE_UNDEFINED = 0,
-    DATA_TYPE_FLOAT = 1,
-    DATA_TYPE_FLOAT16 = 10,
-} tensor_data_type;
+#include "interface.h"
 
-typedef struct {
-    size_t num_tensors;
-    char **names;
-    tensor_data_type *data_types;
-    size_t *ranks;
-    size_t **shapes;
-    void **data;
-} tensors_struct;
-
-/* OAAX C API */
-extern int runtime_initialization(void);
-extern int runtime_model_loading(const char *model_path);
-extern int send_input(tensors_struct *input);
-extern int receive_output(tensors_struct **output);
-extern int runtime_destruction(void);
-extern const char *runtime_name(void);
-extern const char *runtime_version(void);
-
-static tensors_struct *make_squeezenet_input(void)
+/* Build a single-tensor Tensors* for SqueezeNet: [1, 3, 224, 224] float32 */
+static Tensors *make_squeezenet_input(void)
 {
-    /* SqueezeNet input: [1, 3, 224, 224] float32 */
     size_t N = 1, C = 3, H = 224, W = 224;
     size_t n_elements = N * C * H * W;
     size_t n_bytes    = n_elements * sizeof(float);
 
-    tensors_struct *ts = (tensors_struct *)malloc(sizeof(tensors_struct));
-    ts->num_tensors  = 1;
-    ts->names        = (char **)malloc(sizeof(char *));
-    ts->data_types   = (tensor_data_type *)malloc(sizeof(tensor_data_type));
-    ts->ranks        = (size_t *)malloc(sizeof(size_t));
-    ts->shapes       = (size_t **)malloc(sizeof(size_t *));
-    ts->data         = (void **)malloc(sizeof(void *));
+    Tensors *ts = (Tensors *)malloc(sizeof(Tensors));
+    ts->id          = 0;
+    ts->num_tensors = 1;
+    ts->tensors     = (TensorDescriptor *)malloc(sizeof(TensorDescriptor));
 
-    ts->names[0]      = strdup("data");
-    ts->data_types[0] = DATA_TYPE_FLOAT;
-    ts->ranks[0]      = 4;
-    ts->shapes[0]     = (size_t *)malloc(4 * sizeof(size_t));
-    ts->shapes[0][0]  = N;
-    ts->shapes[0][1]  = C;
-    ts->shapes[0][2]  = H;
-    ts->shapes[0][3]  = W;
+    ts->tensors[0].name      = strdup("data");
+    ts->tensors[0].data_type = DATA_TYPE_FLOAT;
+    ts->tensors[0].rank      = 4;
+    ts->tensors[0].shape     = (int *)malloc(4 * sizeof(int));
+    ts->tensors[0].shape[0]  = (int)N;
+    ts->tensors[0].shape[1]  = (int)C;
+    ts->tensors[0].shape[2]  = (int)H;
+    ts->tensors[0].shape[3]  = (int)W;
+    ts->tensors[0].data_size = n_bytes;
 
     float *buf = (float *)malloc(n_bytes);
     for (size_t i = 0; i < n_elements; ++i)
         buf[i] = 0.5f;
-    ts->data[0] = buf;
+    ts->tensors[0].data = buf;
 
     return ts;
 }
 
 int main(void)
 {
-    printf("=== TensorRT Runtime Test ===\n");
-    printf("Runtime: %s\n", runtime_name());
-    printf("Version: %s\n", runtime_version());
+    printf("=== TensorRT Runtime Test (OAAX v2) ===\n");
+    printf("Runtime: %s\n", runtime_get_name());
+    printf("Version: %s\n", runtime_get_version());
 
     /* Initialise */
-    if (runtime_initialization() != 0) {
-        fprintf(stderr, "FAIL: runtime_initialization\n");
+    Config cfg = {0, NULL, NULL};
+    if (runtime_init(cfg) != RUNTIME_STATUS_SUCCESS) {
+        fprintf(stderr, "FAIL: runtime_init — %s\n", runtime_get_error());
         return 1;
     }
-    printf("[OK] runtime_initialization\n");
+    printf("[OK] runtime_init\n");
 
     /* Load model */
     const char *engine_path = "/tmp/trt-output/model.trt";
-    if (runtime_model_loading(engine_path) != 0) {
-        fprintf(stderr, "FAIL: runtime_model_loading (%s)\n", engine_path);
-        runtime_destruction();
+    ModelConfig mc = {engine_path, NULL, 0, {0, NULL, NULL}};
+    if (runtime_load_models(1, &mc) != RUNTIME_STATUS_SUCCESS) {
+        fprintf(stderr, "FAIL: runtime_load_models (%s) — %s\n",
+                engine_path, runtime_get_error());
+        runtime_cleanup();
         return 1;
     }
-    printf("[OK] runtime_model_loading\n");
+    printf("[OK] runtime_load_models\n");
 
-    /* Send input */
-    tensors_struct *input = make_squeezenet_input();
-    if (send_input(input) != 0) {
-        fprintf(stderr, "FAIL: send_input\n");
-        runtime_destruction();
+    /* Enqueue input */
+    Tensors *input = make_squeezenet_input();
+    if (runtime_enqueue_input(0, input) != RUNTIME_STATUS_SUCCESS) {
+        fprintf(stderr, "FAIL: runtime_enqueue_input — %s\n", runtime_get_error());
+        runtime_cleanup();
         return 1;
     }
-    printf("[OK] send_input\n");
+    printf("[OK] runtime_enqueue_input\n");
 
-    /* Poll for output (up to 10s) */
-    tensors_struct *output = NULL;
-    int attempts = 0;
-    while (receive_output(&output) != 0 && attempts++ < 100)
-        /* sleep 100ms (receive_output already sleeps internally) */;
-
-    if (!output) {
-        fprintf(stderr, "FAIL: receive_output timed out\n");
-        runtime_destruction();
+    /* Retrieve output (block up to 10 seconds) */
+    Tensors *output = NULL;
+    int model_id = -1;
+    RuntimeStatus st = runtime_retrieve_output(&model_id, &output, 10000);
+    if (st != RUNTIME_STATUS_SUCCESS || !output) {
+        fprintf(stderr, "FAIL: runtime_retrieve_output (status=%d) — %s\n",
+                st, runtime_get_error());
+        runtime_cleanup();
         return 1;
     }
-    printf("[OK] receive_output: %zu output tensor(s)\n", output->num_tensors);
+    printf("[OK] runtime_retrieve_output: model_id=%d, %d output tensor(s)\n",
+           model_id, output->num_tensors);
 
-    for (size_t i = 0; i < output->num_tensors; ++i) {
-        printf("  [%zu] name=%s  rank=%zu  shape=[",
-               i, output->names[i], output->ranks[i]);
-        for (size_t d = 0; d < output->ranks[i]; ++d)
-            printf("%s%zu", d ? "," : "", output->shapes[i][d]);
-        printf("]  dtype=%d\n", (int)output->data_types[i]);
+    for (int i = 0; i < output->num_tensors; ++i) {
+        TensorDescriptor *td = &output->tensors[i];
+        printf("  [%d] name=%s  rank=%d  shape=[", i, td->name, td->rank);
+        for (int d = 0; d < td->rank; ++d)
+            printf("%s%d", d ? "," : "", td->shape[d]);
+        printf("]  dtype=%d  data_size=%zu\n", (int)td->data_type, td->data_size);
 
         /* Print first 5 float values */
-        if (output->data_types[i] == DATA_TYPE_FLOAT && output->data[i]) {
-            float *vals = (float *)output->data[i];
+        if (td->data_type == DATA_TYPE_FLOAT && td->data) {
+            float *vals = (float *)td->data;
             printf("  first values: ");
-            for (size_t v = 0; v < 5; ++v) printf("%.4f ", vals[v]);
+            for (int v = 0; v < 5; ++v) printf("%.4f ", vals[v]);
             printf("\n");
         }
     }
 
-    /* Cleanup output (caller owns it) */
-    for (size_t i = 0; i < output->num_tensors; ++i) {
-        free(output->names[i]);
-        free(output->shapes[i]);
-        free(output->data[i]);
+    /* Free output (caller owns it) */
+    for (int i = 0; i < output->num_tensors; ++i) {
+        free(output->tensors[i].name);
+        free(output->tensors[i].shape);
+        free(output->tensors[i].data);
     }
-    free(output->names);
-    free(output->data_types);
-    free(output->ranks);
-    free(output->shapes);
-    free(output->data);
+    free(output->tensors);
     free(output);
 
-    runtime_destruction();
-    printf("[OK] runtime_destruction\n");
+    runtime_cleanup();
+    printf("[OK] runtime_cleanup\n");
     printf("=== PASS ===\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

- Replace the v1 `tensors_struct`/integer-return OAAX API with the new OAAX v2 C API (`RuntimeStatus` enum, `TensorDescriptor`/`Tensors` structs, `Config`, `ModelConfig`)
- Add `interface.h` as a self-contained v2 header — removes the external `c_utilities` dependency from CMakeLists
- Upgrade from single-model to multi-model support: each loaded model gets its own `ModelState` (engine, context, CUDA stream, inference thread, input queue); a shared output queue carries `model_id` via `Tensors.id`
- Update test file (`test/test_runtime.c`) to exercise the v2 API end-to-end
- Update README quick-start snippet to show v2 API usage

## Key design decisions

- `Tensors.id` threads `model_id` from `runtime_enqueue_input` through the inference pipeline to `runtime_retrieve_output`, so callers can match outputs to models
- `runtime_retrieve_output(timeout_ms=0)` is non-blocking; `timeout_ms=-1` blocks indefinitely; positive values block up to N ms
- `runtime_get_error()` returns `nullptr` on no error (clean signal), not a static string
- Engine loading accepts either `file_path` or `model_data`/`model_size` in `ModelConfig`

## Test plan

- [ ] Verify syntax: `g++ -std=c++17 -fsyntax-only tensorrt/runtime-library/include/interface.h` (passes clean)
- [ ] Build with cross-compilation toolchain against TRT + CUDA headers (requires GPU build environment)
- [ ] Run `test/test_runtime.c` end-to-end with a `.trt` engine on a GPU machine

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)