### PR TITLE
feat(ort): upgrade C API to OAAX v2 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,16 @@ docker run --rm --gpus all \
 # Output: output/model.trt + output/logs.json
 ```
 
-**2. Run inference** — load `libRuntimeLibrary.so` and use the [OAAX C API](https://github.com/OAAX-standard/OAAX):
+**2. Run inference** — load `libRuntimeLibrary.so` and use the [OAAX v2 C API](https://github.com/OAAX-standard/OAAX):
 ```c
-runtime_initialization(2, (char*[]){"log_level=2", "log_file=runtime.log"});
-runtime_load_model("/path/to/model.trt", model_config_json);
-send_input(tensors);
-receive_output(&out_tensors);
-runtime_destruct();
+Config cfg = {0, NULL, NULL};
+runtime_init(cfg);
+ModelConfig mc = {"/path/to/model.trt", NULL, 0, {0, NULL, NULL}};
+runtime_load_models(1, &mc);
+runtime_enqueue_input(0, input_tensors);
+int model_id; Tensors *out;
+runtime_retrieve_output(&model_id, &out, 5000 /* ms */);
+runtime_cleanup();
 ```
 
 See [`tensorrt/conversion-toolchain/README.md`](tensorrt/conversion-toolchain/README.md) and [`tensorrt/runtime-library/README.md`](tensorrt/runtime-library/README.md) for full details.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NVIDIA GPU implementation of the [OAAX standard](https://github.com/OAAX-standar
 nvidia-acceleration/
 ├── tensorrt/
 │   ├── conversion-toolchain/   # Compiles ONNX → .trt engine (GPU required)
-│   └── runtime-library/        # Loads and runs .trt engines via OAAX C API
+│   └── runtime-library/        # Loads and runs .trt engines via OAAX v2 C API
 ├── onnxruntime/
 │   ├── conversion-toolchain/   # Simplifies ONNX for ORT+CUDA (no GPU needed)
 │   └── runtime-library/        # Runs simplified ONNX via ORT+CUDA EP
@@ -80,13 +80,27 @@ docker run --rm --gpus all \
 # Output: output/model.trt + output/logs.json
 ```
 
-**2. Run inference** — load `libRuntimeLibrary.so` and use the [OAAX C API](https://github.com/OAAX-standard/OAAX):
+**2. Run inference** — load `libRuntimeLibrary.so` and use the [OAAX v2 C API](https://github.com/OAAX-standard/OAAX):
 ```c
-runtime_initialization(2, (char*[]){"log_level=2", "log_file=runtime.log"});
-runtime_load_model("/path/to/model.trt", model_config_json);
-send_input(tensors);
-receive_output(&out_tensors);
-runtime_destruct();
+// Initialize runtime with key-value config
+const char *keys[]   = {"log_level", "log_file"};
+const char *values[] = {"2", "runtime.log"};
+Config cfg = {2, keys, values};
+runtime_init(cfg);
+
+// Load model(s) — supports multiple models at once
+ModelConfig mc = {.file_path = "/path/to/model.trt"};
+runtime_load_models(1, &mc);
+
+// Enqueue input (model_id=0 for first model)
+runtime_enqueue_input(0, input_tensors);
+
+// Retrieve output (blocks up to 1000ms)
+int model_id;
+Tensors *out = NULL;
+runtime_retrieve_output(&model_id, &out, 1000);
+
+runtime_cleanup();
 ```
 
 See [`tensorrt/conversion-toolchain/README.md`](tensorrt/conversion-toolchain/README.md) and [`tensorrt/runtime-library/README.md`](tensorrt/runtime-library/README.md) for full details.
@@ -129,7 +143,7 @@ docker run --rm \
 # Output: output/*-simplified.onnx + output/logs.json
 ```
 
-**2. Run inference** — same OAAX C API, pointing at the simplified `.onnx` file.
+**2. Run inference** — same OAAX v2 C API, pointing at the simplified `.onnx` file.
 
 See [`onnxruntime/conversion-toolchain/README.md`](onnxruntime/conversion-toolchain/README.md) for full details.
 
@@ -151,7 +165,7 @@ See [`onnxruntime/conversion-toolchain/README.md`](onnxruntime/conversion-toolch
 [ ] Dev:     bash tensorrt/conversion-toolchain/build-toolchain.sh
 [ ] Target:  zip bundle.zip model.onnx config.json
 [ ] Target:  docker run ... oaax-nvidia-tensorrt-toolchain → model.trt
-[ ] App:     dlopen libRuntimeLibrary.so, OAAX C API with model.trt
+[ ] App:     dlopen libRuntimeLibrary.so, OAAX v2 C API with model.trt
 ```
 
 For a complete working example see [OAAX-standard/examples](https://github.com/OAAX-standard/examples).

--- a/onnxruntime/runtime-library/include/interface.h
+++ b/onnxruntime/runtime-library/include/interface.h
@@ -1,0 +1,104 @@
+#ifndef OAAX_RUNTIME_INTERFACE_H
+#define OAAX_RUNTIME_INTERFACE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum RuntimeStatus {
+  RUNTIME_STATUS_SUCCESS = 0,
+  RUNTIME_STATUS_ERROR = 1,
+  RUNTIME_STATUS_NOT_INITIALIZED = 2,
+  RUNTIME_STATUS_ALREADY_INITIALIZED = 3,
+  RUNTIME_STATUS_MODEL_NOT_LOADED = 4,
+  RUNTIME_STATUS_INVALID_ARGUMENT = 5,
+  RUNTIME_STATUS_INVALID_MODEL = 6,
+  RUNTIME_STATUS_FILE_NOT_FOUND = 7,
+  RUNTIME_STATUS_OUT_OF_MEMORY = 8,
+  RUNTIME_STATUS_INVALID_TENSOR = 9,
+  RUNTIME_STATUS_TENSOR_SHAPE_MISMATCH = 10,
+  RUNTIME_STATUS_TENSOR_TYPE_MISMATCH = 11,
+  RUNTIME_STATUS_NO_OUTPUT_AVAILABLE = 12,
+  RUNTIME_STATUS_INFERENCE_ERROR = 13,
+  RUNTIME_STATUS_NOT_IMPLEMENTED = 14,
+  RUNTIME_STATUS_TIMEOUT = 15,
+  RUNTIME_STATUS_DEVICE_ERROR = 16,
+  RUNTIME_STATUS_UNKNOWN_ERROR = 17,
+  RUNTIME_STATUS_INVALID_MODEL_ID = 18
+} RuntimeStatus;
+
+typedef enum TensorElementType {
+  DATA_TYPE_UNDEFINED = 0,
+  DATA_TYPE_FLOAT = 1,
+  DATA_TYPE_UINT8 = 2,
+  DATA_TYPE_INT8 = 3,
+  DATA_TYPE_UINT16 = 4,
+  DATA_TYPE_INT16 = 5,
+  DATA_TYPE_INT32 = 6,
+  DATA_TYPE_INT64 = 7,
+  DATA_TYPE_STRING = 8,
+  DATA_TYPE_BOOL = 9,
+  DATA_TYPE_FLOAT16 = 10,
+  DATA_TYPE_DOUBLE = 11,
+  DATA_TYPE_UINT32 = 12,
+  DATA_TYPE_UINT64 = 13,
+  DATA_TYPE_COMPLEX64 = 14,
+  DATA_TYPE_COMPLEX128 = 15,
+  DATA_TYPE_BFLOAT16 = 16,
+  DATA_TYPE_FLOAT8E4M3FN = 17,
+  DATA_TYPE_FLOAT8E4M3FNUZ = 18,
+  DATA_TYPE_FLOAT8E5M2 = 19,
+  DATA_TYPE_FLOAT8E5M2FNUZ = 20,
+  DATA_TYPE_UINT4 = 21,
+  DATA_TYPE_INT4 = 22,
+  DATA_TYPE_FLOAT4E2M1 = 23,
+  DATA_TYPE_FLOAT8E8M0 = 24,
+  DATA_TYPE_UINT2 = 25,
+  DATA_TYPE_INT2 = 26
+} TensorElementType;
+
+typedef struct TensorDescriptor {
+  char              *name;
+  TensorElementType  data_type;
+  int                rank;
+  int               *shape;
+  size_t             data_size;
+  void              *data;
+} TensorDescriptor;
+
+typedef struct Tensors {
+  int               id;
+  int               num_tensors;
+  TensorDescriptor *tensors;
+} Tensors;
+
+typedef struct Config {
+  int          length;
+  const char **keys;
+  const char **values;
+} Config;
+
+typedef struct ModelConfig {
+  const char *file_path;
+  const unsigned char *model_data;
+  size_t model_size;
+  Config config;
+} ModelConfig;
+
+RuntimeStatus runtime_init(Config config);
+RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs);
+RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors);
+RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms);
+RuntimeStatus runtime_cleanup(void);
+const char *runtime_get_error(void);
+const char *runtime_get_version(void);
+const char *runtime_get_name(void);
+const char *runtime_get_info(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OAAX_RUNTIME_INTERFACE_H

--- a/onnxruntime/runtime-library/include/runtime_core.hpp
+++ b/onnxruntime/runtime-library/include/runtime_core.hpp
@@ -1,8 +1,7 @@
-
 #ifndef RUNTIME_CORE_HPP
 #define RUNTIME_CORE_HPP
 
-#include "tensors_struct.h"
+#include "interface.h"
 
 #ifdef _WIN32
 #define EXPOSE_FUNCTION __declspec(dllexport)
@@ -10,22 +9,14 @@
 #define EXPOSE_FUNCTION __attribute__((visibility("default")))
 #endif
 
-extern "C" EXPOSE_FUNCTION int runtime_initialization_with_args(int length, char **keys, void **values);
-
-extern "C" EXPOSE_FUNCTION int runtime_initialization();
-
-extern "C" EXPOSE_FUNCTION int runtime_model_loading(const char *model_path);
-
-extern "C" EXPOSE_FUNCTION int send_input(tensors_struct *input_tensors);
-
-extern "C" EXPOSE_FUNCTION int receive_output(tensors_struct **output_tensors);
-
-extern "C" EXPOSE_FUNCTION int runtime_destruction();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_error_message();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_version();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_name();
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_init(Config config);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_cleanup(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_error(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_version(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_name(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_info(void);
 
 #endif // RUNTIME_CORE_HPP

--- a/onnxruntime/runtime-library/include/runtime_utils.hpp
+++ b/onnxruntime/runtime-library/include/runtime_utils.hpp
@@ -1,4 +1,3 @@
-
 #ifndef RUNTIME_UTILS_HPP
 #define RUNTIME_UTILS_HPP
 
@@ -10,22 +9,16 @@
 
 using namespace std;
 
-// Get output names from the ONNX Runtime session
 vector<char *> get_output_names(Ort::Session &session);
-
-// Map tensor_data_type to ONNX Runtime ONNXTensorElementDataType
-ONNXTensorElementDataType map_to_ort_type(tensor_data_type t);
-
-// Map ONNX Runtime ONNXTensorElementDataType to tensor_data_type
-tensor_data_type map_to_tensors_struct_type(ONNXTensorElementDataType type);
-
+ONNXTensorElementDataType map_to_ort_type(TensorElementType t);
+TensorElementType map_to_tensors_struct_type(ONNXTensorElementDataType type);
+int get_element_byte_size(TensorElementType t);
+void deep_free_tensors(Tensors *t);
+void free_queue(moodycamel::ConcurrentQueue<Tensors *> &queue);
 shared_ptr<spdlog::logger> initialize_logger(const string &log_file,
-                                             int file_level = spdlog::level::info,
-                                             int console_level = spdlog::level::info,
-                                             const string prefix = "OAAX");
-
-void destroy_logger(std::shared_ptr<spdlog::logger> logger);
-
-void free_queue(moodycamel::ConcurrentQueue<tensors_struct *> &queue);
+                                              int file_level,
+                                              int console_level,
+                                              const string &prefix);
+void destroy_logger(const shared_ptr<spdlog::logger> &logger);
 
 #endif // RUNTIME_UTILS_HPP

--- a/onnxruntime/runtime-library/src/runtime_core.cpp
+++ b/onnxruntime/runtime-library/src/runtime_core.cpp
@@ -1,21 +1,14 @@
-#include <iostream>
-#include <vector>
-#include <string>
-#include <queue>
-#include <numeric>
-#include <iostream>
-#include <vector>
-#include <string>
-#include <queue>
-#include <thread>
 #include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
 
 #ifdef _WIN32
 #include <windows.h>
 #endif
 
 #include <onnxruntime_cxx_api.h>
-#include "tensors_struct.h"
 #include "concurrentqueue.h"
 #include <spdlog/spdlog.h>
 
@@ -24,286 +17,288 @@
 
 using namespace std;
 
-// Helper function
-static void inference_thread_func();
+// State
+static bool initialized = false;
+static string last_error_msg;
 
-// ONNX Runtime vars
-static std::unique_ptr<Ort::SessionOptions> session_options;
-static std::unique_ptr<Ort::Env> env;
-static std::unique_ptr<Ort::Session> session;
-// Queue variables
-static moodycamel::ConcurrentQueue<tensors_struct *> input_tensors_queue;
-static moodycamel::ConcurrentQueue<tensors_struct *> output_tensors_queue;
-// Session variables
-static vector<char *> output_names;
-// Threads variables
-static std::thread inference_thread;
-static std::atomic<bool> stop_inference_thread{false};
-// Logger
-std::shared_ptr<spdlog::logger> logger;
-// Runtime arguments
-static int log_level = spdlog::level::info; // Possible values: spdlog::level::trace, debug, info, warn, err, critical, off
+// ORT globals
+static unique_ptr<Ort::Env> env;
+static unique_ptr<Ort::SessionOptions> session_options;
+
+// Per-model state
+struct ModelState {
+    unique_ptr<Ort::Session> session;
+    vector<char *> output_names;
+    moodycamel::ConcurrentQueue<Tensors *> input_queue;
+    thread inference_thread;
+    atomic<bool> stop{false};
+    int model_id;
+};
+
+static vector<unique_ptr<ModelState>> model_states;
+static moodycamel::ConcurrentQueue<Tensors *> output_queue;
+
+// Config
+static int log_level = spdlog::level::info;
 static string log_file = "runtime.log";
 static int num_threads = 4;
 
-extern "C" int runtime_initialization_with_args(int length, char **keys, void **values)
-{
-    for (int i = 0; i < length; ++i)
-    {
-        string key = string(keys[i]);
-        if (key == "log_level")
-        {
-            int value = std::stoi(static_cast<char *>(values[i]));
-            if (value >= spdlog::level::trace && value <= spdlog::level::off)
-                log_level = value;
-            else
-                log_level = spdlog::level::info;
-        }
-        else if (key == "log_file")
-        {
-            log_file = string(static_cast<char *>(values[i]));
-        }
-        else if (key == "num_threads")
-        {
-            num_threads = std::stoi(static_cast<char *>(values[i]));
-            if (num_threads < 1)
-                num_threads = 1;
-            else if (num_threads > 8)
-                num_threads = 8;
-        }
-        else
-        {
-            // Unknown key, ignore
-        }
-    }
+static shared_ptr<spdlog::logger> logger;
 
-    return runtime_initialization();
+static void set_error(const string &msg) {
+    last_error_msg = msg;
+    if (logger) logger->error("{}", msg);
 }
 
-extern "C" int runtime_initialization()
-{
-    try
-    {
-        // Init logger
-        logger = initialize_logger(log_file, log_level, log_level, runtime_name());
-        logger->info("Initializing the runtime");
-        env = std::make_unique<Ort::Env>(ORT_LOGGING_LEVEL_WARNING, runtime_name());
-        logger->trace("ORT logging initialized");
-        session_options = std::make_unique<Ort::SessionOptions>();
-        session_options->SetIntraOpNumThreads(num_threads);
-        // Add CUDA execution provider
-        OrtCUDAProviderOptions cuda_options;
-        cuda_options.device_id = 0; // Use GPU 0
-        cuda_options.arena_extend_strategy = 0;
-        cuda_options.gpu_mem_limit = SIZE_MAX;
-        cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearchExhaustive;
-        cuda_options.do_copy_in_default_stream = 1;
-        session_options->AppendExecutionProvider_CUDA(cuda_options);
-        session_options->SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
-        logger->trace("Session options initialized");
-        stop_inference_thread = false;
-        inference_thread = std::thread(inference_thread_func);
-        logger->info("Inference thread started");
-        logger->info("Runtime arguments:");
-        logger->info("  log_level: {}", log_level);
-        logger->info("  log_file: {}", log_file);
-        logger->info("  num_threads: {}", num_threads);
-        return 0;
+static void stop_and_clear_models() {
+    for (auto &ms : model_states) {
+        ms->stop = true;
+        if (ms->inference_thread.joinable()) ms->inference_thread.join();
+        for (auto n : ms->output_names) free(n);
+        free_queue(ms->input_queue);
     }
-    catch (const std::exception &e)
-    {
-        logger->error("Error during runtime initialization: {}", e.what());
-        return -1;
-    }
+    model_states.clear();
 }
 
-extern "C" int runtime_model_loading(const char *model_path)
+static void inference_thread_func(ModelState *ms)
 {
-    logger->info("Loading model from: {}", model_path);
-    try
-    {
-#ifdef _WIN32
-        // On Windows the Ort::Session constructor expects a wide (UTF-16) string
-        int size_needed = MultiByteToWideChar(CP_UTF8, 0, model_path, -1, NULL, 0);
-        if (size_needed <= 0)
-        {
-            logger->error("Failed to convert model path to wide string.");
-            return -1;
-        }
-        std::wstring wpath(size_needed, 0);
-        MultiByteToWideChar(CP_UTF8, 0, model_path, -1, &wpath[0], size_needed);
-        session = std::make_unique<Ort::Session>(*env, wpath.c_str(), *session_options);
-#else
-        session = std::make_unique<Ort::Session>(*env, model_path, *session_options);
-#endif
-        logger->debug("Model loaded successfully from: {}", model_path);
-        output_names = get_output_names(*session);
-        logger->trace("Output names retrieved successfully");
-        return 0;
-    }
-    catch (const std::exception &e)
-    {
-        logger->error("Error during model loading: {}", e.what());
-        return -1;
-    }
-}
-
-extern "C" int send_input(tensors_struct *input_tensors)
-{
-    // Push the input tensors onto the queue
-    logger->debug("Enqueuing input tensors.");
-    logger->debug("Input queue contains {} tensors.", input_tensors_queue.size_approx());
-    bool success = input_tensors_queue.try_enqueue(input_tensors);
-    if (!success)
-    {
-        logger->warn("Failed to enqueue input tensors.");
-        return -1;
-    }
-    logger->trace("Input tensors enqueued successfully.");
-    return 0;
-}
-
-// Inference thread function: polls for input tensors and runs inference
-static void inference_thread_func()
-{
-    while (!stop_inference_thread)
-    {
-        tensors_struct *input_tensors = nullptr;
-        if (!input_tensors_queue.try_dequeue(input_tensors))
-        {
-            logger->trace("No input tensors available, sleeping for 10ms...");
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    while (!ms->stop) {
+        Tensors *input = nullptr;
+        if (!ms->input_queue.try_dequeue(input)) {
+            this_thread::sleep_for(chrono::milliseconds(5));
             continue;
         }
-        logger->debug("Input tensors dequeued successfully.");
-        Ort::AllocatorWithDefaultOptions allocator_;
-        std::vector<const char *> input_names;
-        std::vector<Ort::Value> ort_inputs;
-        logger->trace("Preparing input tensors for inference...");
-        for (size_t i = 0; i < input_tensors->num_tensors; ++i)
-        {
-            logger->trace("Preparing input tensor {}...", i);
-            input_names.push_back(input_tensors->names[i]);
-            std::vector<int64_t> shape;
-            for (size_t j = 0; j < input_tensors->ranks[i]; ++j)
-                shape.push_back(static_cast<int64_t>(input_tensors->shapes[i][j]));
-            ONNXTensorElementDataType dtype = map_to_ort_type(input_tensors->data_types[i]);
-            int dtype_size = get_data_type_byte_size(input_tensors->data_types[i]);
-            int tensor_size = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<int64_t>()) * dtype_size;
-            ort_inputs.push_back(Ort::Value::CreateTensor(
-                Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault),
-                input_tensors->data[i],
-                tensor_size,
-                shape.data(),
-                shape.size(),
-                dtype));
-        }
-        logger->debug("Performing inference...");
-        std::vector<Ort::Value> ort_outputs = session->Run(
-            Ort::RunOptions{nullptr},
-            input_names.data(),
-            ort_inputs.data(),
-            ort_inputs.size(),
-            output_names.data(),
-            output_names.size());
-        logger->debug("Inference completed.");
-        deep_free_tensors_struct(input_tensors);
-        logger->trace("Freed input tensors.");
-        tensors_struct *output_tensors = allocate_tensors_struct(ort_outputs.size());
-        logger->trace("Building output tensors.");
-        for (size_t i = 0; i < ort_outputs.size(); ++i)
-        {
-            logger->trace("Building output tensor {}...", i);
-            size_t name_len = strlen(output_names[i]);
-            output_tensors->names[i] = (char *)malloc(name_len + 1);
-            strcpy(output_tensors->names[i], output_names[i]);
+        logger->debug("Model {}: dequeued input id={}", ms->model_id, input->id);
 
-            std::vector<int64_t> shape = ort_outputs[i].GetTensorTypeAndShapeInfo().GetShape();
-            output_tensors->ranks[i] = shape.size();
-            output_tensors->shapes[i] = (size_t *)malloc(sizeof(size_t) * shape.size());
-            for (size_t j = 0; j < shape.size(); ++j)
-                output_tensors->shapes[i][j] = static_cast<size_t>(shape[j]);
+        try {
+            vector<const char *> input_names;
+            vector<Ort::Value> ort_inputs;
 
-            output_tensors->data_types[i] = map_to_tensors_struct_type(ort_outputs[i].GetTensorTypeAndShapeInfo().GetElementType());
-
-            size_t data_size = ort_outputs[i].GetTensorTypeAndShapeInfo().GetElementCount() *
-                               get_data_type_byte_size(output_tensors->data_types[i]);
-            output_tensors->data[i] = (void *)malloc(data_size);
-            if (!output_tensors->data[i])
-            {
-                throw std::runtime_error("Failed to allocate memory for output tensor data.");
+            for (int i = 0; i < input->num_tensors; ++i) {
+                TensorDescriptor &td = input->tensors[i];
+                input_names.push_back(td.name);
+                vector<int64_t> shape(td.shape, td.shape + td.rank);
+                ONNXTensorElementDataType dtype = map_to_ort_type(td.data_type);
+                ort_inputs.push_back(Ort::Value::CreateTensor(
+                    Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeDefault),
+                    td.data, td.data_size,
+                    shape.data(), shape.size(), dtype));
             }
-            memcpy(output_tensors->data[i], ort_outputs[i].GetTensorMutableData<void>(), data_size);
+
+            int req_id = input->id;
+            deep_free_tensors(input);
+            input = nullptr;
+
+            auto ort_outputs = ms->session->Run(
+                Ort::RunOptions{nullptr},
+                input_names.data(), ort_inputs.data(), ort_inputs.size(),
+                ms->output_names.data(), ms->output_names.size());
+
+            size_t n = ort_outputs.size();
+            Tensors *out = (Tensors *)malloc(sizeof(Tensors));
+            out->id = req_id;
+            out->num_tensors = (int)n;
+            out->tensors = (TensorDescriptor *)malloc(n * sizeof(TensorDescriptor));
+
+            for (size_t i = 0; i < n; ++i) {
+                TensorDescriptor &td = out->tensors[i];
+                size_t name_len = strlen(ms->output_names[i]);
+                td.name = (char *)malloc(name_len + 1);
+                memcpy(td.name, ms->output_names[i], name_len + 1);
+
+                auto info = ort_outputs[i].GetTensorTypeAndShapeInfo();
+                auto shape = info.GetShape();
+                td.rank = (int)shape.size();
+                td.shape = (int *)malloc(td.rank * sizeof(int));
+                for (int j = 0; j < td.rank; ++j)
+                    td.shape[j] = (int)shape[j];
+
+                td.data_type = map_to_tensors_struct_type(info.GetElementType());
+                size_t elem_count = info.GetElementCount();
+                td.data_size = elem_count * (size_t)get_element_byte_size(td.data_type);
+                td.data = malloc(td.data_size);
+                memcpy(td.data, ort_outputs[i].GetTensorMutableData<void>(), td.data_size);
+            }
+
+            if (!output_queue.try_enqueue(out)) {
+                logger->error("Failed to enqueue output");
+                deep_free_tensors(out);
+            }
+        } catch (const exception &e) {
+            if (input) deep_free_tensors(input);
+            logger->error("Inference error: {}", e.what());
         }
-        logger->trace("Output tensors built successfully.");
-        int success = output_tensors_queue.try_enqueue(output_tensors);
-        if (!success)
-        {
-            logger->error("Failed to enqueue output tensors.");
-        }
-        logger->debug("Output tensors enqueued successfully.");
     }
 }
 
-extern "C" int receive_output(tensors_struct **output_tensors)
+extern "C" RuntimeStatus runtime_init(Config config)
 {
-    logger->debug("Waiting for output tensors...");
-    logger->debug("Output queue contains {} tensors.", output_tensors_queue.size_approx());
-    // Check if there are any output tensors in the queue
-    if (output_tensors_queue.size_approx() == 0)
-    {
-        // Sleep for 1ms
-        logger->debug("No output tensors available, sleeping for 1ms...");
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        logger->trace("Woke up from sleep.");
-        return -1;
+    if (initialized) {
+        set_error("Runtime already initialized");
+        return RUNTIME_STATUS_ALREADY_INITIALIZED;
     }
-    // Get the next output tensor from the queue
-    if (!output_tensors_queue.try_dequeue(*output_tensors))
-    {
-        logger->error("Failed to dequeue output tensors.");
-        return -1;
+
+    for (int i = 0; i < config.length; ++i) {
+        string key = config.keys[i];
+        string val = config.values[i];
+        if (key == "log_level") {
+            int v = stoi(val);
+            log_level = (v >= spdlog::level::trace && v <= spdlog::level::off) ? v : spdlog::level::info;
+        } else if (key == "log_file") {
+            log_file = val;
+        } else if (key == "num_threads") {
+            num_threads = max(1, min(8, stoi(val)));
+        }
     }
-    logger->debug("Output tensors received successfully.");
-    return 0;
+
+    try {
+        logger = initialize_logger(log_file, log_level, log_level, runtime_get_name());
+        logger->info("Initializing ORT runtime");
+        env = make_unique<Ort::Env>(ORT_LOGGING_LEVEL_WARNING, runtime_get_name());
+        session_options = make_unique<Ort::SessionOptions>();
+        session_options->SetIntraOpNumThreads(num_threads);
+        OrtCUDAProviderOptions cuda_opts{};
+        cuda_opts.device_id = 0;
+        cuda_opts.arena_extend_strategy = 0;
+        cuda_opts.gpu_mem_limit = SIZE_MAX;
+        cuda_opts.cudnn_conv_algo_search = OrtCudnnConvAlgoSearchExhaustive;
+        cuda_opts.do_copy_in_default_stream = 1;
+        session_options->AppendExecutionProvider_CUDA(cuda_opts);
+        session_options->SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+        initialized = true;
+        logger->info("Runtime initialized (log_level={}, num_threads={})", log_level, num_threads);
+        return RUNTIME_STATUS_SUCCESS;
+    } catch (const exception &e) {
+        set_error(string("runtime_init failed: ") + e.what());
+        return RUNTIME_STATUS_ERROR;
+    }
 }
 
-extern "C" int runtime_destruction()
+extern "C" RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs)
 {
-    logger->info("Destroying runtime...");
-    stop_inference_thread = true;
-    logger->trace("Waiting for inference thread to stop...");
-    if (inference_thread.joinable())
-        inference_thread.join();
-    logger->trace("Inference thread stopped.");
-    for (auto name : output_names)
-        free(name);
-    logger->trace("Freed output tensor names.");
-    free_queue(input_tensors_queue);
-    logger->trace("Freed input tensor queue.");
-    free_queue(output_tensors_queue);
-    logger->trace("Freed output tensor queue.");
-    session.reset();
-    logger->trace("Freed ONNX runtime session.");
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (num_models <= 0 || !model_configs) return RUNTIME_STATUS_INVALID_ARGUMENT;
+
+    stop_and_clear_models();
+    free_queue(output_queue);
+
+    try {
+        for (int i = 0; i < num_models; ++i) {
+            const ModelConfig &mc = model_configs[i];
+            auto ms = make_unique<ModelState>();
+            ms->model_id = i;
+
+#ifdef _WIN32
+            if (mc.file_path) {
+                int sz = MultiByteToWideChar(CP_UTF8, 0, mc.file_path, -1, NULL, 0);
+                wstring wpath(sz, 0);
+                MultiByteToWideChar(CP_UTF8, 0, mc.file_path, -1, &wpath[0], sz);
+                ms->session = make_unique<Ort::Session>(*env, wpath.c_str(), *session_options);
+            }
+#else
+            if (mc.file_path) {
+                ms->session = make_unique<Ort::Session>(*env, mc.file_path, *session_options);
+            } else if (mc.model_data && mc.model_size > 0) {
+                ms->session = make_unique<Ort::Session>(*env, mc.model_data, mc.model_size, *session_options);
+            } else {
+                set_error("ModelConfig must have file_path or model_data");
+                model_states.clear();
+                return RUNTIME_STATUS_INVALID_ARGUMENT;
+            }
+#endif
+            ms->output_names = get_output_names(*ms->session);
+            logger->info("Model {}: loaded, {} outputs", i, ms->output_names.size());
+
+            ms->inference_thread = thread(inference_thread_func, ms.get());
+            model_states.push_back(move(ms));
+        }
+        return RUNTIME_STATUS_SUCCESS;
+    } catch (const exception &e) {
+        stop_and_clear_models();
+        set_error(string("runtime_load_models failed: ") + e.what());
+        return RUNTIME_STATUS_ERROR;
+    }
+}
+
+extern "C" RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors)
+{
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (model_id < 0 || (size_t)model_id >= model_states.size()) return RUNTIME_STATUS_INVALID_MODEL_ID;
+    if (!input_tensors) return RUNTIME_STATUS_INVALID_ARGUMENT;
+
+    // Store model_id in the id field so retrieve_output can return it
+    input_tensors->id = model_id;
+
+    if (!model_states[model_id]->input_queue.try_enqueue(input_tensors)) {
+        set_error("Failed to enqueue input tensors");
+        return RUNTIME_STATUS_ERROR;
+    }
+    return RUNTIME_STATUS_SUCCESS;
+}
+
+extern "C" RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms)
+{
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (!model_id || !output_tensors) return RUNTIME_STATUS_INVALID_ARGUMENT;
+
+    if (timeout_ms == 0) {
+        if (!output_queue.try_dequeue(*output_tensors))
+            return RUNTIME_STATUS_NO_OUTPUT_AVAILABLE;
+        *model_id = (*output_tensors)->id;
+        return RUNTIME_STATUS_SUCCESS;
+    }
+
+    auto start = chrono::steady_clock::now();
+    while (true) {
+        if (output_queue.try_dequeue(*output_tensors)) {
+            *model_id = (*output_tensors)->id;
+            return RUNTIME_STATUS_SUCCESS;
+        }
+        auto elapsed = chrono::duration_cast<chrono::milliseconds>(
+            chrono::steady_clock::now() - start).count();
+        if (elapsed >= timeout_ms)
+            return RUNTIME_STATUS_NO_OUTPUT_AVAILABLE;
+        this_thread::sleep_for(chrono::milliseconds(1));
+    }
+}
+
+extern "C" RuntimeStatus runtime_cleanup(void)
+{
+    stop_and_clear_models();
+    free_queue(output_queue);
     session_options.reset();
-    logger->trace("Freed ONNX runtime session options.");
     env.reset();
-    logger->debug("Runtime destroyed.");
-    destroy_logger(logger);
-    return 0;
+    initialized = false;
+    last_error_msg.clear();
+    if (logger) {
+        logger->info("Runtime cleaned up");
+        destroy_logger(logger);
+        logger = nullptr;
+    }
+    return RUNTIME_STATUS_SUCCESS;
 }
 
-extern "C" const char *runtime_error_message()
+extern "C" const char *runtime_get_error(void)
 {
-    return "Check the stdout and/or log files for any error message.";
+    return last_error_msg.empty() ? nullptr : last_error_msg.c_str();
 }
 
-extern "C" const char *runtime_version()
+extern "C" const char *runtime_get_version(void)
 {
     return RUNTIME_VERSION;
 }
 
-extern "C" const char *runtime_name()
+extern "C" const char *runtime_get_name(void)
 {
-    return "OAAX NVIDIA Runtime";
+    return "OAAX NVIDIA OnnxRuntime";
+}
+
+extern "C" const char *runtime_get_info(void)
+{
+    if (!initialized) return nullptr;
+    static char buf[256];
+    snprintf(buf, sizeof(buf),
+             "{\"loaded_models\":%zu,\"requests_in_flight\":%zu}",
+             model_states.size(), output_queue.size_approx());
+    return buf;
 }

--- a/onnxruntime/runtime-library/src/runtime_utils.cpp
+++ b/onnxruntime/runtime-library/src/runtime_utils.cpp
@@ -1,160 +1,143 @@
 #include <iostream>
 #include <vector>
+#include <stdexcept>
 
 #include "runtime_utils.hpp"
 #include <onnxruntime_cxx_api.h>
 #include "concurrentqueue.h"
 
 #include <spdlog/async.h>
-#include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
 using namespace std;
 
+void deep_free_tensors(Tensors *t)
+{
+    if (!t) return;
+    for (int i = 0; i < t->num_tensors; ++i) {
+        free(t->tensors[i].name);
+        free(t->tensors[i].shape);
+        free(t->tensors[i].data);
+    }
+    free(t->tensors);
+    free(t);
+}
+
+void free_queue(moodycamel::ConcurrentQueue<Tensors *> &queue)
+{
+    Tensors *t;
+    while (queue.try_dequeue(t))
+        deep_free_tensors(t);
+}
+
 vector<char *> get_output_names(Ort::Session &session)
 {
-    // Define the allocator
     Ort::AllocatorWithDefaultOptions allocator;
-    // Read number of outputs
-    size_t output_count = session.GetOutputCount();
-    // Create names holder
-    std::vector<char *> output_names;
-    output_names.reserve(output_count);
-    // Read output names
-    for (size_t i = 0; i < output_count; ++i)
-    {
-        Ort::AllocatedStringPtr nameAllocated = session.GetOutputNameAllocated(i, allocator);
-        output_names.emplace_back(nameAllocated.release()); // transfer ownership
+    size_t count = session.GetOutputCount();
+    vector<char *> names;
+    names.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        Ort::AllocatedStringPtr p = session.GetOutputNameAllocated(i, allocator);
+        names.emplace_back(p.release());
     }
-    // Return
-    return output_names;
+    return names;
 }
 
-// Map tensor_data_type to ONNX Runtime ONNXTensorElementDataType
-ONNXTensorElementDataType map_to_ort_type(tensor_data_type t)
+ONNXTensorElementDataType map_to_ort_type(TensorElementType t)
 {
-    switch (t)
-    {
-    case DATA_TYPE_FLOAT:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
-    case DATA_TYPE_UINT8:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
-    case DATA_TYPE_INT8:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
-    case DATA_TYPE_UINT16:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
-    case DATA_TYPE_INT16:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
-    case DATA_TYPE_INT32:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
-    case DATA_TYPE_INT64:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
-    case DATA_TYPE_BOOL:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
-    case DATA_TYPE_DOUBLE:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
-    case DATA_TYPE_UINT32:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32;
-    case DATA_TYPE_UINT64:
-        return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64;
+    switch (t) {
+    case DATA_TYPE_FLOAT:   return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+    case DATA_TYPE_UINT8:   return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+    case DATA_TYPE_INT8:    return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
+    case DATA_TYPE_UINT16:  return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
+    case DATA_TYPE_INT16:   return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16;
+    case DATA_TYPE_INT32:   return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+    case DATA_TYPE_INT64:   return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+    case DATA_TYPE_BOOL:    return ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL;
+    case DATA_TYPE_DOUBLE:  return ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
+    case DATA_TYPE_UINT32:  return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32;
+    case DATA_TYPE_UINT64:  return ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64;
+    case DATA_TYPE_FLOAT16: return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
     default:
-        throw std::runtime_error("Unsupported data type!");
+        throw runtime_error("Unsupported TensorElementType for ORT mapping");
     }
 }
 
-// Map ONNX Runtime ONNXTensorElementDataType to tensor_data_type
-tensor_data_type map_to_tensors_struct_type(ONNXTensorElementDataType type)
+TensorElementType map_to_tensors_struct_type(ONNXTensorElementDataType type)
 {
-    switch (type)
-    {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
-        return DATA_TYPE_FLOAT;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-        return DATA_TYPE_UINT8;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-        return DATA_TYPE_INT8;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
-        return DATA_TYPE_UINT16;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
-        return DATA_TYPE_INT16;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
-        return DATA_TYPE_INT32;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
-        return DATA_TYPE_INT64;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
-        return DATA_TYPE_BOOL;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
-        return DATA_TYPE_DOUBLE;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
-        return DATA_TYPE_UINT32;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
-        return DATA_TYPE_UINT64;
+    switch (type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:   return DATA_TYPE_FLOAT;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:   return DATA_TYPE_UINT8;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:    return DATA_TYPE_INT8;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:  return DATA_TYPE_UINT16;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:   return DATA_TYPE_INT16;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:   return DATA_TYPE_INT32;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:   return DATA_TYPE_INT64;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:    return DATA_TYPE_BOOL;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:  return DATA_TYPE_DOUBLE;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:  return DATA_TYPE_UINT32;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:  return DATA_TYPE_UINT64;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16: return DATA_TYPE_FLOAT16;
     default:
-        throw std::runtime_error("Unsupported data type!");
+        throw runtime_error("Unsupported ORT type for OAAX mapping");
     }
 }
 
-void free_queue(moodycamel::ConcurrentQueue<tensors_struct *> &queue)
+int get_element_byte_size(TensorElementType t)
 {
-    tensors_struct *tensor;
-    while (queue.try_dequeue(tensor))
-    {
-        deep_free_tensors_struct(tensor);
+    switch (t) {
+    case DATA_TYPE_FLOAT:    return 4;
+    case DATA_TYPE_DOUBLE:   return 8;
+    case DATA_TYPE_INT8:     return 1;
+    case DATA_TYPE_UINT8:    return 1;
+    case DATA_TYPE_INT16:    return 2;
+    case DATA_TYPE_UINT16:   return 2;
+    case DATA_TYPE_FLOAT16:  return 2;
+    case DATA_TYPE_BFLOAT16: return 2;
+    case DATA_TYPE_INT32:    return 4;
+    case DATA_TYPE_UINT32:   return 4;
+    case DATA_TYPE_INT64:    return 8;
+    case DATA_TYPE_UINT64:   return 8;
+    case DATA_TYPE_BOOL:     return 1;
+    default:                 return 1;
     }
 }
 
-std::shared_ptr<spdlog::logger> initialize_logger(const string &log_file,
-                                                  int file_level,
-                                                  int console_level,
-                                                  const string prefix)
+shared_ptr<spdlog::logger> initialize_logger(const string &log_file,
+                                              int file_level,
+                                              int console_level,
+                                              const string &prefix)
 {
-    try
-    {
-        // Create a console logger
+    try {
         auto console_sink = make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        console_sink->set_level(
-            static_cast<spdlog::level::level_enum>(console_level));
+        console_sink->set_level(static_cast<spdlog::level::level_enum>(console_level));
 
-        // Create a rotating file logger
         auto file_sink = make_shared<spdlog::sinks::rotating_file_sink_st>(
-            log_file, 1024 * 1024 * 5, 3); // 5MB max size, 3 rotated files
-        file_sink->set_level(
-            static_cast<spdlog::level::level_enum>(file_level));
+            log_file, 1024 * 1024 * 5, 3);
+        file_sink->set_level(static_cast<spdlog::level::level_enum>(file_level));
 
-        // Configure the thread pool for async logging
-        static auto thread_pool =
-            make_shared<spdlog::details::thread_pool>(8192, 1);
+        static auto thread_pool = make_shared<spdlog::details::thread_pool>(8192, 1);
 
-        // Create the async logger with both sinks using the thread pool
         auto logger = make_shared<spdlog::async_logger>(
             prefix, spdlog::sinks_init_list{console_sink, file_sink},
             thread_pool, spdlog::async_overflow_policy::overrun_oldest);
 
-        // Set the logging pattern
-        spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [" + prefix +
-                            "] [%^%l%$] %v");
-
-        // Set the logger level to the lowest level among the sinks
+        spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [" + prefix + "] [%^%l%$] %v");
         logger->set_level(static_cast<spdlog::level::level_enum>(
-            std::min(file_level, console_level)));
-
-        return logger; // Return the logger instance
-    }
-    catch (const spdlog::spdlog_ex &ex)
-    {
-        cerr << "Logger initialization failed: " << ex.what() << "\n";
+            min(file_level, console_level)));
+        return logger;
+    } catch (const spdlog::spdlog_ex &ex) {
+        cerr << "Logger init failed: " << ex.what() << "\n";
         exit(EXIT_FAILURE);
     }
 }
 
-void destroy_logger(std::shared_ptr<spdlog::logger> logger)
+void destroy_logger(const shared_ptr<spdlog::logger> &logger)
 {
-    if (logger)
-    {
+    if (logger) {
         logger->flush();
         spdlog::drop(logger->name());
-        logger = nullptr; // This destroys the logger and frees resources
     }
 }

--- a/tensorrt/runtime-library/CMakeLists.txt
+++ b/tensorrt/runtime-library/CMakeLists.txt
@@ -139,13 +139,6 @@ FetchContent_Declare(concurrentqueue
     GIT_SHALLOW    TRUE)
 FetchContent_MakeAvailable(concurrentqueue)
 
-# tools repo contains c-utilities as a subdirectory
-FetchContent_Declare(tools
-    GIT_REPOSITORY https://github.com/OAAX-standard/tools
-    GIT_TAG        main
-    GIT_SHALLOW    TRUE
-    SOURCE_SUBDIR  c-utilities)
-FetchContent_MakeAvailable(tools)
 
 # === Library Target ===
 file(GLOB_RECURSE SRC
@@ -192,7 +185,6 @@ target_link_libraries(RuntimeLibrary PUBLIC
     nvinfer_plugin
     cudart
     spdlog::spdlog
-    c_utilities
     stdc++
     -Wl,--end-group)
 

--- a/tensorrt/runtime-library/README.md
+++ b/tensorrt/runtime-library/README.md
@@ -1,6 +1,22 @@
 # Runtime Library
 
-C++ shared library (`libRuntimeLibrary.so`) that implements the OAAX C API using native TensorRT. It deserializes a `.trt` engine produced by the conversion toolchain and runs inference on an NVIDIA GPU.
+C++ shared library (`libRuntimeLibrary.so`) that implements the OAAX v2 C API using native TensorRT. It deserializes a `.trt` engine produced by the conversion toolchain and runs inference on an NVIDIA GPU.
+
+## API overview
+
+| Function | Description |
+|---|---|
+| `runtime_init(Config)` | Initialize the runtime with key-value configuration |
+| `runtime_load_models(n, ModelConfig[])` | Load one or more models; each is assigned an integer `model_id` |
+| `runtime_enqueue_input(model_id, Tensors*)` | Enqueue input tensors for a specific model (non-blocking) |
+| `runtime_retrieve_output(&model_id, &Tensors*, timeout_ms)` | Retrieve output tensors; blocks up to `timeout_ms` |
+| `runtime_cleanup()` | Free all resources |
+| `runtime_get_error()` | Return the last error message |
+| `runtime_get_version()` | Return the runtime version string |
+| `runtime_get_name()` | Return the runtime name string |
+| `runtime_get_info()` | Return a JSON string with diagnostic information |
+
+Key types: `Config` (`{length, keys[], values[]}`), `ModelConfig` (`{file_path, model_data, model_size, config}`), `Tensors` (`{id, num_tensors, TensorDescriptor[]}`), `RuntimeStatus` (return code enum).
 
 ## Build the runtime
 
@@ -79,7 +95,7 @@ Verify: `nvidia-smi`
 
 ## Test
 
-A standalone C test is provided in `test/test_runtime.c`. It exercises the full OAAX API cycle. Run it inside the toolchain container (which has TensorRT installed):
+A standalone C test is provided in `test/test_runtime.c`. It exercises the full OAAX v2 API cycle (`runtime_init` → `runtime_load_models` → `runtime_enqueue_input` → `runtime_retrieve_output` → `runtime_cleanup`). Run it inside the toolchain container (which has TensorRT installed):
 
 ```bash
 docker run --rm --gpus all \

--- a/tensorrt/runtime-library/include/interface.h
+++ b/tensorrt/runtime-library/include/interface.h
@@ -1,0 +1,104 @@
+#ifndef OAAX_RUNTIME_INTERFACE_H
+#define OAAX_RUNTIME_INTERFACE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum RuntimeStatus {
+  RUNTIME_STATUS_SUCCESS = 0,
+  RUNTIME_STATUS_ERROR = 1,
+  RUNTIME_STATUS_NOT_INITIALIZED = 2,
+  RUNTIME_STATUS_ALREADY_INITIALIZED = 3,
+  RUNTIME_STATUS_MODEL_NOT_LOADED = 4,
+  RUNTIME_STATUS_INVALID_ARGUMENT = 5,
+  RUNTIME_STATUS_INVALID_MODEL = 6,
+  RUNTIME_STATUS_FILE_NOT_FOUND = 7,
+  RUNTIME_STATUS_OUT_OF_MEMORY = 8,
+  RUNTIME_STATUS_INVALID_TENSOR = 9,
+  RUNTIME_STATUS_TENSOR_SHAPE_MISMATCH = 10,
+  RUNTIME_STATUS_TENSOR_TYPE_MISMATCH = 11,
+  RUNTIME_STATUS_NO_OUTPUT_AVAILABLE = 12,
+  RUNTIME_STATUS_INFERENCE_ERROR = 13,
+  RUNTIME_STATUS_NOT_IMPLEMENTED = 14,
+  RUNTIME_STATUS_TIMEOUT = 15,
+  RUNTIME_STATUS_DEVICE_ERROR = 16,
+  RUNTIME_STATUS_UNKNOWN_ERROR = 17,
+  RUNTIME_STATUS_INVALID_MODEL_ID = 18
+} RuntimeStatus;
+
+typedef enum TensorElementType {
+  DATA_TYPE_UNDEFINED = 0,
+  DATA_TYPE_FLOAT = 1,
+  DATA_TYPE_UINT8 = 2,
+  DATA_TYPE_INT8 = 3,
+  DATA_TYPE_UINT16 = 4,
+  DATA_TYPE_INT16 = 5,
+  DATA_TYPE_INT32 = 6,
+  DATA_TYPE_INT64 = 7,
+  DATA_TYPE_STRING = 8,
+  DATA_TYPE_BOOL = 9,
+  DATA_TYPE_FLOAT16 = 10,
+  DATA_TYPE_DOUBLE = 11,
+  DATA_TYPE_UINT32 = 12,
+  DATA_TYPE_UINT64 = 13,
+  DATA_TYPE_COMPLEX64 = 14,
+  DATA_TYPE_COMPLEX128 = 15,
+  DATA_TYPE_BFLOAT16 = 16,
+  DATA_TYPE_FLOAT8E4M3FN = 17,
+  DATA_TYPE_FLOAT8E4M3FNUZ = 18,
+  DATA_TYPE_FLOAT8E5M2 = 19,
+  DATA_TYPE_FLOAT8E5M2FNUZ = 20,
+  DATA_TYPE_UINT4 = 21,
+  DATA_TYPE_INT4 = 22,
+  DATA_TYPE_FLOAT4E2M1 = 23,
+  DATA_TYPE_FLOAT8E8M0 = 24,
+  DATA_TYPE_UINT2 = 25,
+  DATA_TYPE_INT2 = 26
+} TensorElementType;
+
+typedef struct TensorDescriptor {
+  char              *name;
+  TensorElementType  data_type;
+  int                rank;
+  int               *shape;
+  size_t             data_size;
+  void              *data;
+} TensorDescriptor;
+
+typedef struct Tensors {
+  int               id;
+  int               num_tensors;
+  TensorDescriptor *tensors;
+} Tensors;
+
+typedef struct Config {
+  int          length;
+  const char **keys;
+  const char **values;
+} Config;
+
+typedef struct ModelConfig {
+  const char *file_path;
+  const unsigned char *model_data;
+  size_t model_size;
+  Config config;
+} ModelConfig;
+
+RuntimeStatus runtime_init(Config config);
+RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs);
+RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors);
+RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms);
+RuntimeStatus runtime_cleanup(void);
+const char *runtime_get_error(void);
+const char *runtime_get_version(void);
+const char *runtime_get_name(void);
+const char *runtime_get_info(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OAAX_RUNTIME_INTERFACE_H

--- a/tensorrt/runtime-library/include/runtime_core.hpp
+++ b/tensorrt/runtime-library/include/runtime_core.hpp
@@ -1,28 +1,18 @@
 #ifndef RUNTIME_CORE_HPP
 #define RUNTIME_CORE_HPP
 
-extern "C" {
-#include "tensors_struct.h"
-}
+#include "interface.h"
 
 #define EXPOSE_FUNCTION __attribute__((visibility("default")))
 
-extern "C" EXPOSE_FUNCTION int runtime_initialization_with_args(int length, char **keys, void **values);
-
-extern "C" EXPOSE_FUNCTION int runtime_initialization();
-
-extern "C" EXPOSE_FUNCTION int runtime_model_loading(const char *model_path);
-
-extern "C" EXPOSE_FUNCTION int send_input(tensors_struct *input_tensors);
-
-extern "C" EXPOSE_FUNCTION int receive_output(tensors_struct **output_tensors);
-
-extern "C" EXPOSE_FUNCTION int runtime_destruction();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_error_message();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_version();
-
-extern "C" EXPOSE_FUNCTION const char *runtime_name();
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_init(Config config);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms);
+extern "C" EXPOSE_FUNCTION RuntimeStatus runtime_cleanup(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_error(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_version(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_name(void);
+extern "C" EXPOSE_FUNCTION const char *runtime_get_info(void);
 
 #endif // RUNTIME_CORE_HPP

--- a/tensorrt/runtime-library/include/runtime_utils.hpp
+++ b/tensorrt/runtime-library/include/runtime_utils.hpp
@@ -10,22 +10,15 @@
 
 using namespace std;
 
-// Map a TensorRT DataType to the OAAX tensor_data_type enum
-tensor_data_type map_trt_to_oaax_type(nvinfer1::DataType dtype);
-
-// Return the byte size of a single element for a TensorRT DataType
+TensorElementType map_trt_to_oaax_type(nvinfer1::DataType dtype);
 size_t trt_dtype_byte_size(nvinfer1::DataType dtype);
-
-// Compute total byte size of a tensor given its dims and dtype
 size_t compute_tensor_byte_size(const nvinfer1::Dims &dims, nvinfer1::DataType dtype);
-
+void deep_free_tensors(Tensors *t);
+void free_queue(moodycamel::ConcurrentQueue<Tensors *> &queue);
 shared_ptr<spdlog::logger> initialize_logger(const string &log_file,
-                                             int file_level = spdlog::level::info,
-                                             int console_level = spdlog::level::info,
-                                             const string prefix = "OAAX");
-
+                                              int file_level,
+                                              int console_level,
+                                              const string prefix);
 void destroy_logger(shared_ptr<spdlog::logger> logger);
-
-void free_queue(moodycamel::ConcurrentQueue<tensors_struct *> &queue);
 
 #endif // RUNTIME_UTILS_HPP

--- a/tensorrt/runtime-library/src/runtime_core.cpp
+++ b/tensorrt/runtime-library/src/runtime_core.cpp
@@ -1,4 +1,5 @@
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <fstream>
 #include <stdexcept>
@@ -11,397 +12,350 @@
 #include "concurrentqueue.h"
 #include <spdlog/spdlog.h>
 
-#include "runtime_core.hpp"   // pulls in tensors_struct.h with extern "C"
+#include "runtime_core.hpp"
 #include "runtime_utils.hpp"
 
 using namespace std;
 
-// Forward declaration
-static void inference_thread_func();
-
-// TRT logger: forwards TRT messages to spdlog
-class TrtLogger : public nvinfer1::ILogger
-{
+// TRT ILogger forwarding to spdlog
+class TrtLogger : public nvinfer1::ILogger {
 public:
-    void log(Severity severity, const char *msg) noexcept override;
+    void log(Severity sev, const char *msg) noexcept override;
 };
 static TrtLogger trt_logger;
 
-// TRT objects
-static nvinfer1::IRuntime *trt_runtime = nullptr;
-static nvinfer1::ICudaEngine *engine = nullptr;
-static nvinfer1::IExecutionContext *context = nullptr;
-static cudaStream_t infer_stream = nullptr;
-
-// Per-tensor info populated at model load time
+// Per-tensor info for one model
 struct TensorInfo {
-    std::string name;
+    string name;
     bool is_input;
     nvinfer1::Dims dims;
     nvinfer1::DataType dtype;
     size_t byte_size;
     void *gpu_buf = nullptr;
 };
-static std::vector<TensorInfo> tensor_infos;
-static std::vector<size_t> input_indices;   // indices into tensor_infos
-static std::vector<size_t> output_indices;  // indices into tensor_infos
 
-// Input/output queues
-static moodycamel::ConcurrentQueue<tensors_struct *> input_tensors_queue;
-static moodycamel::ConcurrentQueue<tensors_struct *> output_tensors_queue;
+// Per-model runtime state
+struct ModelState {
+    int model_id;
+    nvinfer1::ICudaEngine *engine = nullptr;
+    nvinfer1::IExecutionContext *context = nullptr;
+    cudaStream_t stream = nullptr;
+    vector<TensorInfo> tensor_infos;
+    vector<size_t> input_indices;
+    vector<size_t> output_indices;
+    moodycamel::ConcurrentQueue<Tensors *> input_queue;
+    thread inference_thread;
+    atomic<bool> stop{false};
+};
 
-// Inference thread
-static std::thread inference_thread;
-static std::atomic<bool> stop_inference_thread{false};
+static bool initialized = false;
+static string last_error_msg;
+static int log_level_val = spdlog::level::info;
+static string log_file_val = "runtime.log";
 
-// Logger and runtime config
-std::shared_ptr<spdlog::logger> logger;
-static int log_level = spdlog::level::info;
-static std::string log_file = "runtime.log";
+static nvinfer1::IRuntime *trt_runtime = nullptr;
+static vector<unique_ptr<ModelState>> model_states;
+static moodycamel::ConcurrentQueue<Tensors *> output_queue;
 
-// TrtLogger implementation
-void TrtLogger::log(Severity severity, const char *msg) noexcept
-{
-    if (!logger)
-        return;
-    switch (severity)
-    {
+shared_ptr<spdlog::logger> logger;
+
+static void set_error(const string &msg) {
+    last_error_msg = msg;
+    if (logger) logger->error("{}", msg);
+}
+
+void TrtLogger::log(Severity sev, const char *msg) noexcept {
+    if (!logger) return;
+    switch (sev) {
     case Severity::kINTERNAL_ERROR:
-    case Severity::kERROR:
-        logger->error("[TRT] {}", msg);
-        break;
-    case Severity::kWARNING:
-        logger->warn("[TRT] {}", msg);
-        break;
-    case Severity::kINFO:
-        logger->info("[TRT] {}", msg);
-        break;
-    case Severity::kVERBOSE:
-        logger->trace("[TRT] {}", msg);
-        break;
+    case Severity::kERROR:   logger->error("[TRT] {}", msg); break;
+    case Severity::kWARNING: logger->warn("[TRT] {}", msg);  break;
+    case Severity::kINFO:    logger->info("[TRT] {}", msg);  break;
+    case Severity::kVERBOSE: logger->trace("[TRT] {}", msg); break;
     }
 }
 
-extern "C" int runtime_initialization_with_args(int length, char **keys, void **values)
-{
-    for (int i = 0; i < length; ++i)
-    {
-        std::string key(keys[i]);
-        if (key == "log_level")
-        {
-            int value = std::stoi(static_cast<char *>(values[i]));
-            log_level = (value >= spdlog::level::trace && value <= spdlog::level::off)
-                            ? value
-                            : spdlog::level::info;
-        }
-        else if (key == "log_file")
-        {
-            log_file = std::string(static_cast<char *>(values[i]));
-        }
-    }
-    return runtime_initialization();
+static void destroy_model_state(ModelState *ms) {
+    if (!ms) return;
+    ms->stop = true;
+    if (ms->inference_thread.joinable()) ms->inference_thread.join();
+    free_queue(ms->input_queue);
+    for (auto &ti : ms->tensor_infos)
+        if (ti.gpu_buf) { cudaFree(ti.gpu_buf); ti.gpu_buf = nullptr; }
+    if (ms->stream)  { cudaStreamDestroy(ms->stream); ms->stream = nullptr; }
+    if (ms->context) { delete ms->context; ms->context = nullptr; }
+    if (ms->engine)  { delete ms->engine;  ms->engine  = nullptr; }
 }
 
-extern "C" int runtime_initialization()
+static void inference_thread_func(ModelState *ms)
 {
-    try
-    {
-        logger = initialize_logger(log_file, log_level, log_level, runtime_name());
-        logger->info("Initializing TensorRT runtime");
-
-        trt_runtime = nvinfer1::createInferRuntime(trt_logger);
-        if (!trt_runtime)
-            throw std::runtime_error("Failed to create TRT IRuntime");
-
-        stop_inference_thread = false;
-        inference_thread = std::thread(inference_thread_func);
-
-        logger->info("Inference thread started");
-        logger->info("Runtime arguments: log_level={}, log_file={}", log_level, log_file);
-        return 0;
-    }
-    catch (const std::exception &e)
-    {
-        if (logger)
-            logger->error("Initialization failed: {}", e.what());
-        return -1;
-    }
-}
-
-extern "C" int runtime_model_loading(const char *model_path)
-{
-    logger->info("Loading TRT engine from: {}", model_path);
-    try
-    {
-        // Read engine file into memory
-        std::ifstream file(model_path, std::ios::binary | std::ios::ate);
-        if (!file.is_open())
-            throw std::runtime_error(std::string("Cannot open engine file: ") + model_path);
-        size_t file_size = static_cast<size_t>(file.tellg());
-        file.seekg(0, std::ios::beg);
-        std::vector<char> engine_data(file_size);
-        file.read(engine_data.data(), static_cast<std::streamsize>(file_size));
-        file.close();
-
-        // Deserialize the engine
-        engine = trt_runtime->deserializeCudaEngine(engine_data.data(), file_size);
-        if (!engine)
-            throw std::runtime_error("Failed to deserialize TRT engine");
-
-        context = engine->createExecutionContext();
-        if (!context)
-            throw std::runtime_error("Failed to create TRT execution context");
-
-        if (cudaStreamCreate(&infer_stream) != cudaSuccess)
-            throw std::runtime_error("Failed to create CUDA stream");
-
-        // Build tensor info and allocate persistent GPU buffers
-        int nb_tensors = engine->getNbIOTensors();
-        tensor_infos.clear();
-        input_indices.clear();
-        output_indices.clear();
-        tensor_infos.resize(static_cast<size_t>(nb_tensors));
-
-        for (int i = 0; i < nb_tensors; ++i)
-        {
-            const char *name = engine->getIOTensorName(i);
-            TensorInfo &ti = tensor_infos[static_cast<size_t>(i)];
-            ti.name = name;
-            ti.is_input = (engine->getTensorIOMode(name) == nvinfer1::TensorIOMode::kINPUT);
-            ti.dims = engine->getTensorShape(name);
-            ti.dtype = engine->getTensorDataType(name);
-            ti.byte_size = compute_tensor_byte_size(ti.dims, ti.dtype);
-
-            if (cudaMalloc(&ti.gpu_buf, ti.byte_size) != cudaSuccess)
-                throw std::runtime_error(std::string("cudaMalloc failed for tensor: ") + name);
-
-            if (ti.is_input)
-                input_indices.push_back(static_cast<size_t>(i));
-            else
-                output_indices.push_back(static_cast<size_t>(i));
-
-            logger->info("  Tensor {}: name={} {} dtype={} byte_size={}",
-                         i, name,
-                         ti.is_input ? "INPUT" : "OUTPUT",
-                         static_cast<int>(ti.dtype),
-                         ti.byte_size);
-        }
-
-        logger->info("Engine loaded: {} inputs, {} outputs",
-                     input_indices.size(), output_indices.size());
-        return 0;
-    }
-    catch (const std::exception &e)
-    {
-        logger->error("Model loading failed: {}", e.what());
-        return -1;
-    }
-}
-
-extern "C" int send_input(tensors_struct *input_tensors)
-{
-    logger->debug("Enqueuing input. Queue size: ~{}", input_tensors_queue.size_approx());
-    if (!input_tensors_queue.try_enqueue(input_tensors))
-    {
-        logger->warn("Failed to enqueue input tensors");
-        return -1;
-    }
-    logger->trace("Input enqueued");
-    return 0;
-}
-
-static void inference_thread_func()
-{
-    while (!stop_inference_thread)
-    {
-        tensors_struct *input_tensors = nullptr;
-        if (!input_tensors_queue.try_dequeue(input_tensors))
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    while (!ms->stop) {
+        Tensors *input = nullptr;
+        if (!ms->input_queue.try_dequeue(input)) {
+            this_thread::sleep_for(chrono::milliseconds(5));
             continue;
         }
-        logger->debug("Dequeued input, running inference");
+        logger->debug("Model {}: dequeued input id={}", ms->model_id, input->id);
 
-        // Pre-allocate host output buffers so we can pipeline D2H with inference
-        std::vector<void *> host_out_bufs(output_indices.size(), nullptr);
+        vector<void *> host_out_bufs(ms->output_indices.size(), nullptr);
+        int req_id = input->id;
 
-        try
-        {
-            if (input_tensors->num_tensors != input_indices.size())
-                throw std::runtime_error("Input tensor count mismatch with engine");
+        try {
+            if ((size_t)input->num_tensors != ms->input_indices.size())
+                throw runtime_error("Input tensor count mismatch");
 
-            // Allocate host output buffers (needed before enqueuing D2H copies)
-            for (size_t i = 0; i < output_indices.size(); ++i)
-            {
-                host_out_bufs[i] = malloc(tensor_infos[output_indices[i]].byte_size);
-                if (!host_out_bufs[i])
-                    throw std::runtime_error("malloc failed for output buffer");
+            for (size_t i = 0; i < ms->output_indices.size(); ++i) {
+                host_out_bufs[i] = malloc(ms->tensor_infos[ms->output_indices[i]].byte_size);
+                if (!host_out_bufs[i]) throw runtime_error("malloc failed for output buffer");
             }
 
-            // H2D: copy inputs to GPU (async, queued on infer_stream)
-            for (size_t i = 0; i < input_indices.size(); ++i)
-            {
-                TensorInfo &ti = tensor_infos[input_indices[i]];
-                if (cudaMemcpyAsync(ti.gpu_buf, input_tensors->data[i], ti.byte_size,
-                                    cudaMemcpyHostToDevice, infer_stream) != cudaSuccess)
-                    throw std::runtime_error("cudaMemcpyAsync H2D failed");
+            for (size_t i = 0; i < ms->input_indices.size(); ++i) {
+                TensorInfo &ti = ms->tensor_infos[ms->input_indices[i]];
+                if (cudaMemcpyAsync(ti.gpu_buf, input->tensors[i].data, ti.byte_size,
+                                    cudaMemcpyHostToDevice, ms->stream) != cudaSuccess)
+                    throw runtime_error("cudaMemcpyAsync H2D failed");
             }
 
-            // Bind all tensor addresses (inputs and outputs)
-            for (auto &ti : tensor_infos)
-                context->setTensorAddress(ti.name.c_str(), ti.gpu_buf);
+            for (auto &ti : ms->tensor_infos)
+                ms->context->setTensorAddress(ti.name.c_str(), ti.gpu_buf);
 
-            // Enqueue inference
-            if (!context->enqueueV3(infer_stream))
-                throw std::runtime_error("TRT enqueueV3 failed");
+            if (!ms->context->enqueueV3(ms->stream))
+                throw runtime_error("TRT enqueueV3 failed");
 
-            // D2H: copy outputs from GPU (async, queued after inference on same stream)
-            for (size_t i = 0; i < output_indices.size(); ++i)
-            {
-                TensorInfo &ti = tensor_infos[output_indices[i]];
+            for (size_t i = 0; i < ms->output_indices.size(); ++i) {
+                TensorInfo &ti = ms->tensor_infos[ms->output_indices[i]];
                 if (cudaMemcpyAsync(host_out_bufs[i], ti.gpu_buf, ti.byte_size,
-                                    cudaMemcpyDeviceToHost, infer_stream) != cudaSuccess)
-                    throw std::runtime_error("cudaMemcpyAsync D2H failed");
+                                    cudaMemcpyDeviceToHost, ms->stream) != cudaSuccess)
+                    throw runtime_error("cudaMemcpyAsync D2H failed");
             }
 
-            // Wait for the full pipeline (H2D + inference + D2H) to complete
-            if (cudaStreamSynchronize(infer_stream) != cudaSuccess)
-                throw std::runtime_error("cudaStreamSynchronize failed");
+            if (cudaStreamSynchronize(ms->stream) != cudaSuccess)
+                throw runtime_error("cudaStreamSynchronize failed");
 
-            deep_free_tensors_struct(input_tensors);
-            input_tensors = nullptr;
+            deep_free_tensors(input);
+            input = nullptr;
 
-            // Build output tensors_struct; host_out_bufs[i] ownership transferred
-            size_t n_out = output_indices.size();
-            tensors_struct *output_tensors =
-                static_cast<tensors_struct *>(malloc(sizeof(tensors_struct)));
-            output_tensors->num_tensors = n_out;
-            output_tensors->names      = static_cast<char **>(malloc(sizeof(char *) * n_out));
-            output_tensors->data_types = static_cast<tensor_data_type *>(
-                malloc(sizeof(tensor_data_type) * n_out));
-            output_tensors->ranks      = static_cast<size_t *>(malloc(sizeof(size_t) * n_out));
-            output_tensors->shapes     = static_cast<size_t **>(malloc(sizeof(size_t *) * n_out));
-            output_tensors->data       = static_cast<void **>(malloc(sizeof(void *) * n_out));
+            size_t n_out = ms->output_indices.size();
+            Tensors *out = (Tensors *)malloc(sizeof(Tensors));
+            out->id = req_id;
+            out->num_tensors = (int)n_out;
+            out->tensors = (TensorDescriptor *)malloc(n_out * sizeof(TensorDescriptor));
 
-            for (size_t i = 0; i < output_indices.size(); ++i)
-            {
-                TensorInfo &ti = tensor_infos[output_indices[i]];
+            for (size_t i = 0; i < n_out; ++i) {
+                TensorInfo &ti = ms->tensor_infos[ms->output_indices[i]];
+                TensorDescriptor &td = out->tensors[i];
 
-                output_tensors->names[i] = static_cast<char *>(malloc(ti.name.size() + 1));
-                strcpy(output_tensors->names[i], ti.name.c_str());
+                td.name = strdup(ti.name.c_str());
 
-                output_tensors->data_types[i] = map_trt_to_oaax_type(ti.dtype);
+                td.data_type = map_trt_to_oaax_type(ti.dtype);
+                td.rank = ti.dims.nbDims;
+                td.shape = (int *)malloc(td.rank * sizeof(int));
+                for (int d = 0; d < td.rank; ++d)
+                    td.shape[d] = (int)ti.dims.d[d];
 
-                output_tensors->ranks[i] = static_cast<size_t>(ti.dims.nbDims);
-                output_tensors->shapes[i] = static_cast<size_t *>(
-                    malloc(sizeof(size_t) * static_cast<size_t>(ti.dims.nbDims)));
-                for (int d = 0; d < ti.dims.nbDims; ++d)
-                    output_tensors->shapes[i][static_cast<size_t>(d)] =
-                        static_cast<size_t>(ti.dims.d[d]);
-
-                output_tensors->data[i] = host_out_bufs[i]; // transfer ownership
+                td.data_size = ti.byte_size;
+                td.data = host_out_bufs[i];
                 host_out_bufs[i] = nullptr;
             }
 
-            if (!output_tensors_queue.try_enqueue(output_tensors))
-            {
-                logger->error("Failed to enqueue output tensors");
-                deep_free_tensors_struct(output_tensors);
+            if (!output_queue.try_enqueue(out)) {
+                logger->error("Failed to enqueue output");
+                deep_free_tensors(out);
             }
-            else
-            {
-                logger->debug("Output enqueued");
-            }
-        }
-        catch (const std::exception &e)
-        {
+        } catch (const exception &e) {
+            if (input) deep_free_tensors(input);
+            for (void *buf : host_out_bufs) free(buf);
             logger->error("Inference error: {}", e.what());
-            if (input_tensors)
-                deep_free_tensors_struct(input_tensors);
-            for (void *buf : host_out_bufs)
-                free(buf);
         }
     }
 }
 
-extern "C" int receive_output(tensors_struct **output_tensors)
+extern "C" RuntimeStatus runtime_init(Config config)
 {
-    logger->debug("Checking for output. Queue size: ~{}", output_tensors_queue.size_approx());
-    if (output_tensors_queue.size_approx() == 0)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        return -1;
+    if (initialized) {
+        set_error("Runtime already initialized");
+        return RUNTIME_STATUS_ALREADY_INITIALIZED;
     }
-    if (!output_tensors_queue.try_dequeue(*output_tensors))
-    {
-        logger->error("Failed to dequeue output tensors");
-        return -1;
+
+    for (int i = 0; i < config.length; ++i) {
+        string key = config.keys[i];
+        string val = config.values[i];
+        if (key == "log_level") {
+            int v = stoi(val);
+            log_level_val = (v >= spdlog::level::trace && v <= spdlog::level::off) ? v : spdlog::level::info;
+        } else if (key == "log_file") {
+            log_file_val = val;
+        }
     }
-    logger->debug("Output received");
-    return 0;
+
+    try {
+        logger = initialize_logger(log_file_val, log_level_val, log_level_val, runtime_get_name());
+        logger->info("Initializing TensorRT runtime");
+        trt_runtime = nvinfer1::createInferRuntime(trt_logger);
+        if (!trt_runtime) throw runtime_error("Failed to create TRT IRuntime");
+        initialized = true;
+        logger->info("Runtime initialized (log_level={})", log_level_val);
+        return RUNTIME_STATUS_SUCCESS;
+    } catch (const exception &e) {
+        set_error(string("runtime_init failed: ") + e.what());
+        return RUNTIME_STATUS_ERROR;
+    }
 }
 
-extern "C" int runtime_destruction()
+extern "C" RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs)
 {
-    logger->info("Destroying runtime...");
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (num_models <= 0 || !model_configs) return RUNTIME_STATUS_INVALID_ARGUMENT;
 
-    stop_inference_thread = true;
-    if (inference_thread.joinable())
-        inference_thread.join();
-    logger->trace("Inference thread stopped");
+    for (auto &ms : model_states) destroy_model_state(ms.get());
+    model_states.clear();
+    free_queue(output_queue);
 
-    free_queue(input_tensors_queue);
-    free_queue(output_tensors_queue);
+    try {
+        for (int i = 0; i < num_models; ++i) {
+            const ModelConfig &mc = model_configs[i];
+            auto ms = make_unique<ModelState>();
+            ms->model_id = i;
 
-    // Free persistent GPU buffers
-    for (auto &ti : tensor_infos)
-    {
-        if (ti.gpu_buf)
-            cudaFree(ti.gpu_buf);
+            vector<char> engine_data;
+            if (mc.file_path) {
+                ifstream file(mc.file_path, ios::binary | ios::ate);
+                if (!file.is_open()) {
+                    set_error(string("Cannot open engine file: ") + mc.file_path);
+                    for (auto &s : model_states) destroy_model_state(s.get());
+                    model_states.clear();
+                    return RUNTIME_STATUS_FILE_NOT_FOUND;
+                }
+                size_t sz = (size_t)file.tellg();
+                file.seekg(0, ios::beg);
+                engine_data.resize(sz);
+                file.read(engine_data.data(), (streamsize)sz);
+                ms->engine = trt_runtime->deserializeCudaEngine(engine_data.data(), sz);
+            } else if (mc.model_data && mc.model_size > 0) {
+                ms->engine = trt_runtime->deserializeCudaEngine(mc.model_data, mc.model_size);
+            } else {
+                set_error("ModelConfig must have file_path or model_data");
+                for (auto &s : model_states) destroy_model_state(s.get());
+                model_states.clear();
+                return RUNTIME_STATUS_INVALID_ARGUMENT;
+            }
+
+            if (!ms->engine) throw runtime_error("Failed to deserialize TRT engine");
+            ms->context = ms->engine->createExecutionContext();
+            if (!ms->context) throw runtime_error("Failed to create execution context");
+            if (cudaStreamCreate(&ms->stream) != cudaSuccess) throw runtime_error("cudaStreamCreate failed");
+
+            int nb = ms->engine->getNbIOTensors();
+            ms->tensor_infos.resize((size_t)nb);
+            for (int j = 0; j < nb; ++j) {
+                const char *name = ms->engine->getIOTensorName(j);
+                TensorInfo &ti = ms->tensor_infos[(size_t)j];
+                ti.name = name;
+                ti.is_input = (ms->engine->getTensorIOMode(name) == nvinfer1::TensorIOMode::kINPUT);
+                ti.dims = ms->engine->getTensorShape(name);
+                ti.dtype = ms->engine->getTensorDataType(name);
+                ti.byte_size = compute_tensor_byte_size(ti.dims, ti.dtype);
+                if (cudaMalloc(&ti.gpu_buf, ti.byte_size) != cudaSuccess)
+                    throw runtime_error(string("cudaMalloc failed for tensor: ") + name);
+                if (ti.is_input)
+                    ms->input_indices.push_back((size_t)j);
+                else
+                    ms->output_indices.push_back((size_t)j);
+            }
+
+            logger->info("Model {}: {} inputs, {} outputs", i, ms->input_indices.size(), ms->output_indices.size());
+            ms->inference_thread = thread(inference_thread_func, ms.get());
+            model_states.push_back(move(ms));
+        }
+        return RUNTIME_STATUS_SUCCESS;
+    } catch (const exception &e) {
+        for (auto &ms : model_states) destroy_model_state(ms.get());
+        model_states.clear();
+        set_error(string("runtime_load_models failed: ") + e.what());
+        return RUNTIME_STATUS_ERROR;
     }
-    tensor_infos.clear();
-    input_indices.clear();
-    output_indices.clear();
-
-    if (infer_stream)
-    {
-        cudaStreamDestroy(infer_stream);
-        infer_stream = nullptr;
-    }
-
-    // TRT objects must be destroyed in reverse creation order
-    if (context)
-    {
-        delete context;
-        context = nullptr;
-    }
-    if (engine)
-    {
-        delete engine;
-        engine = nullptr;
-    }
-    if (trt_runtime)
-    {
-        delete trt_runtime;
-        trt_runtime = nullptr;
-    }
-
-    logger->debug("Runtime destroyed");
-    destroy_logger(logger);
-    return 0;
 }
 
-extern "C" const char *runtime_error_message()
+extern "C" RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors)
 {
-    return "Check the stdout and/or log files for any error message.";
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (model_id < 0 || (size_t)model_id >= model_states.size()) return RUNTIME_STATUS_INVALID_MODEL_ID;
+    if (!input_tensors) return RUNTIME_STATUS_INVALID_ARGUMENT;
+
+    input_tensors->id = model_id;
+
+    if (!model_states[(size_t)model_id]->input_queue.try_enqueue(input_tensors)) {
+        set_error("Failed to enqueue input tensors");
+        return RUNTIME_STATUS_ERROR;
+    }
+    return RUNTIME_STATUS_SUCCESS;
 }
 
-extern "C" const char *runtime_version()
+extern "C" RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms)
+{
+    if (!initialized) return RUNTIME_STATUS_NOT_INITIALIZED;
+    if (!model_id || !output_tensors) return RUNTIME_STATUS_INVALID_ARGUMENT;
+
+    if (timeout_ms == 0) {
+        if (!output_queue.try_dequeue(*output_tensors))
+            return RUNTIME_STATUS_NO_OUTPUT_AVAILABLE;
+        *model_id = (*output_tensors)->id;
+        return RUNTIME_STATUS_SUCCESS;
+    }
+
+    auto start = chrono::steady_clock::now();
+    while (true) {
+        if (output_queue.try_dequeue(*output_tensors)) {
+            *model_id = (*output_tensors)->id;
+            return RUNTIME_STATUS_SUCCESS;
+        }
+        if (timeout_ms > 0) {
+            auto elapsed = chrono::duration_cast<chrono::milliseconds>(
+                chrono::steady_clock::now() - start).count();
+            if (elapsed >= timeout_ms)
+                return RUNTIME_STATUS_NO_OUTPUT_AVAILABLE;
+        }
+        this_thread::sleep_for(chrono::milliseconds(1));
+    }
+}
+
+extern "C" RuntimeStatus runtime_cleanup(void)
+{
+    for (auto &ms : model_states) destroy_model_state(ms.get());
+    model_states.clear();
+    free_queue(output_queue);
+    if (trt_runtime) { delete trt_runtime; trt_runtime = nullptr; }
+    initialized = false;
+    last_error_msg.clear();
+    if (logger) {
+        logger->info("Runtime cleaned up");
+        destroy_logger(logger);
+        logger = nullptr;
+    }
+    return RUNTIME_STATUS_SUCCESS;
+}
+
+extern "C" const char *runtime_get_error(void)
+{
+    return last_error_msg.empty() ? nullptr : last_error_msg.c_str();
+}
+
+extern "C" const char *runtime_get_version(void)
 {
     return RUNTIME_VERSION;
 }
 
-extern "C" const char *runtime_name()
+extern "C" const char *runtime_get_name(void)
 {
-    return "OAAX NVIDIA TensorRT Runtime";
+    return "OAAX NVIDIA TensorRT";
+}
+
+extern "C" const char *runtime_get_info(void)
+{
+    if (!initialized) return nullptr;
+    static char buf[256];
+    snprintf(buf, sizeof(buf),
+             "{\"loaded_models\":%zu,\"requests_in_flight\":%zu}",
+             model_states.size(), output_queue.size_approx());
+    return buf;
 }

--- a/tensorrt/runtime-library/src/runtime_utils.cpp
+++ b/tensorrt/runtime-library/src/runtime_utils.cpp
@@ -8,10 +8,28 @@
 
 using namespace std;
 
-tensor_data_type map_trt_to_oaax_type(nvinfer1::DataType dtype)
+void deep_free_tensors(Tensors *t)
 {
-    switch (dtype)
-    {
+    if (!t) return;
+    for (int i = 0; i < t->num_tensors; ++i) {
+        free(t->tensors[i].name);
+        free(t->tensors[i].shape);
+        free(t->tensors[i].data);
+    }
+    free(t->tensors);
+    free(t);
+}
+
+void free_queue(moodycamel::ConcurrentQueue<Tensors *> &queue)
+{
+    Tensors *t;
+    while (queue.try_dequeue(t))
+        deep_free_tensors(t);
+}
+
+TensorElementType map_trt_to_oaax_type(nvinfer1::DataType dtype)
+{
+    switch (dtype) {
     case nvinfer1::DataType::kFLOAT:  return DATA_TYPE_FLOAT;
     case nvinfer1::DataType::kHALF:   return DATA_TYPE_FLOAT16;
     case nvinfer1::DataType::kBF16:   return DATA_TYPE_BFLOAT16;
@@ -21,14 +39,13 @@ tensor_data_type map_trt_to_oaax_type(nvinfer1::DataType dtype)
     case nvinfer1::DataType::kINT64:  return DATA_TYPE_INT64;
     case nvinfer1::DataType::kBOOL:   return DATA_TYPE_BOOL;
     default:
-        throw std::runtime_error("Unsupported TensorRT data type");
+        throw runtime_error("Unsupported TensorRT data type");
     }
 }
 
 size_t trt_dtype_byte_size(nvinfer1::DataType dtype)
 {
-    switch (dtype)
-    {
+    switch (dtype) {
     case nvinfer1::DataType::kFLOAT:  return 4;
     case nvinfer1::DataType::kHALF:   return 2;
     case nvinfer1::DataType::kBF16:   return 2;
@@ -38,7 +55,7 @@ size_t trt_dtype_byte_size(nvinfer1::DataType dtype)
     case nvinfer1::DataType::kINT64:  return 8;
     case nvinfer1::DataType::kBOOL:   return 1;
     default:
-        throw std::runtime_error("Unsupported TensorRT data type");
+        throw runtime_error("Unsupported TensorRT data type");
     }
 }
 
@@ -46,57 +63,42 @@ size_t compute_tensor_byte_size(const nvinfer1::Dims &dims, nvinfer1::DataType d
 {
     size_t count = 1;
     for (int i = 0; i < dims.nbDims; ++i)
-        count *= static_cast<size_t>(dims.d[i]);
+        count *= (size_t)dims.d[i];
     return count * trt_dtype_byte_size(dtype);
 }
 
-void free_queue(moodycamel::ConcurrentQueue<tensors_struct *> &queue)
-{
-    tensors_struct *tensor;
-    while (queue.try_dequeue(tensor))
-        deep_free_tensors_struct(tensor);
-}
-
 shared_ptr<spdlog::logger> initialize_logger(const string &log_file,
-                                             int file_level,
-                                             int console_level,
-                                             const string prefix)
+                                              int file_level,
+                                              int console_level,
+                                              const string prefix)
 {
-    try
-    {
+    try {
         auto console_sink = make_shared<spdlog::sinks::stdout_color_sink_mt>();
         console_sink->set_level(static_cast<spdlog::level::level_enum>(console_level));
 
         auto file_sink = make_shared<spdlog::sinks::rotating_file_sink_st>(
-            log_file, 1024 * 1024 * 5, 3); // 5 MB, 3 rotated files
+            log_file, 1024 * 1024 * 5, 3);
         file_sink->set_level(static_cast<spdlog::level::level_enum>(file_level));
 
         static auto thread_pool = make_shared<spdlog::details::thread_pool>(8192, 1);
-
         auto logger = make_shared<spdlog::async_logger>(
             prefix, spdlog::sinks_init_list{console_sink, file_sink},
             thread_pool, spdlog::async_overflow_policy::overrun_oldest);
 
         spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [" + prefix + "] [%^%l%$] %v");
-        logger->set_level(static_cast<spdlog::level::level_enum>(
-            std::min(file_level, console_level)));
+        logger->set_level(static_cast<spdlog::level::level_enum>(min(file_level, console_level)));
         logger->flush_on(spdlog::level::info);
-
         return logger;
-    }
-    catch (const spdlog::spdlog_ex &ex)
-    {
-        cerr << "Logger initialization failed: " << ex.what() << "\n";
+    } catch (const spdlog::spdlog_ex &ex) {
+        cerr << "Logger init failed: " << ex.what() << "\n";
         exit(EXIT_FAILURE);
     }
 }
 
 void destroy_logger(shared_ptr<spdlog::logger> logger)
 {
-    if (logger)
-    {
+    if (logger) {
         logger->flush();
         spdlog::drop(logger->name());
-        logger = nullptr;
     }
 }

--- a/tensorrt/runtime-library/test/test_runtime.c
+++ b/tensorrt/runtime-library/test/test_runtime.c
@@ -1,144 +1,117 @@
 /*
- * Minimal test for the TensorRT-native runtime library.
- * Tests load → send_input → receive_output with SqueezeNet (1,3,224,224).
+ * Minimal test for the TensorRT-native runtime library (OAAX v2 API).
+ * Tests init → load_models → enqueue_input → retrieve_output with SqueezeNet (1,3,224,224).
  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
-/* OAAX tensors_struct (must match the definition in c_utilities) */
-typedef enum {
-    DATA_TYPE_UNDEFINED = 0,
-    DATA_TYPE_FLOAT = 1,
-    DATA_TYPE_FLOAT16 = 10,
-} tensor_data_type;
+#include "interface.h"
 
-typedef struct {
-    size_t num_tensors;
-    char **names;
-    tensor_data_type *data_types;
-    size_t *ranks;
-    size_t **shapes;
-    void **data;
-} tensors_struct;
-
-/* OAAX C API */
-extern int runtime_initialization(void);
-extern int runtime_model_loading(const char *model_path);
-extern int send_input(tensors_struct *input);
-extern int receive_output(tensors_struct **output);
-extern int runtime_destruction(void);
-extern const char *runtime_name(void);
-extern const char *runtime_version(void);
-
-static tensors_struct *make_squeezenet_input(void)
+/* Build a single-tensor Tensors* for SqueezeNet: [1, 3, 224, 224] float32 */
+static Tensors *make_squeezenet_input(void)
 {
-    /* SqueezeNet input: [1, 3, 224, 224] float32 */
     size_t N = 1, C = 3, H = 224, W = 224;
     size_t n_elements = N * C * H * W;
     size_t n_bytes    = n_elements * sizeof(float);
 
-    tensors_struct *ts = (tensors_struct *)malloc(sizeof(tensors_struct));
-    ts->num_tensors  = 1;
-    ts->names        = (char **)malloc(sizeof(char *));
-    ts->data_types   = (tensor_data_type *)malloc(sizeof(tensor_data_type));
-    ts->ranks        = (size_t *)malloc(sizeof(size_t));
-    ts->shapes       = (size_t **)malloc(sizeof(size_t *));
-    ts->data         = (void **)malloc(sizeof(void *));
+    Tensors *ts = (Tensors *)malloc(sizeof(Tensors));
+    ts->id          = 0;
+    ts->num_tensors = 1;
+    ts->tensors     = (TensorDescriptor *)malloc(sizeof(TensorDescriptor));
 
-    ts->names[0]      = strdup("data");
-    ts->data_types[0] = DATA_TYPE_FLOAT;
-    ts->ranks[0]      = 4;
-    ts->shapes[0]     = (size_t *)malloc(4 * sizeof(size_t));
-    ts->shapes[0][0]  = N;
-    ts->shapes[0][1]  = C;
-    ts->shapes[0][2]  = H;
-    ts->shapes[0][3]  = W;
+    ts->tensors[0].name      = strdup("data");
+    ts->tensors[0].data_type = DATA_TYPE_FLOAT;
+    ts->tensors[0].rank      = 4;
+    ts->tensors[0].shape     = (int *)malloc(4 * sizeof(int));
+    ts->tensors[0].shape[0]  = (int)N;
+    ts->tensors[0].shape[1]  = (int)C;
+    ts->tensors[0].shape[2]  = (int)H;
+    ts->tensors[0].shape[3]  = (int)W;
+    ts->tensors[0].data_size = n_bytes;
 
     float *buf = (float *)malloc(n_bytes);
     for (size_t i = 0; i < n_elements; ++i)
         buf[i] = 0.5f;
-    ts->data[0] = buf;
+    ts->tensors[0].data = buf;
 
     return ts;
 }
 
 int main(void)
 {
-    printf("=== TensorRT Runtime Test ===\n");
-    printf("Runtime: %s\n", runtime_name());
-    printf("Version: %s\n", runtime_version());
+    printf("=== TensorRT Runtime Test (OAAX v2) ===\n");
+    printf("Runtime: %s\n", runtime_get_name());
+    printf("Version: %s\n", runtime_get_version());
 
     /* Initialise */
-    if (runtime_initialization() != 0) {
-        fprintf(stderr, "FAIL: runtime_initialization\n");
+    Config cfg = {0, NULL, NULL};
+    if (runtime_init(cfg) != RUNTIME_STATUS_SUCCESS) {
+        fprintf(stderr, "FAIL: runtime_init — %s\n", runtime_get_error());
         return 1;
     }
-    printf("[OK] runtime_initialization\n");
+    printf("[OK] runtime_init\n");
 
     /* Load model */
     const char *engine_path = "/tmp/trt-output/model.trt";
-    if (runtime_model_loading(engine_path) != 0) {
-        fprintf(stderr, "FAIL: runtime_model_loading (%s)\n", engine_path);
-        runtime_destruction();
+    ModelConfig mc = {engine_path, NULL, 0, {0, NULL, NULL}};
+    if (runtime_load_models(1, &mc) != RUNTIME_STATUS_SUCCESS) {
+        fprintf(stderr, "FAIL: runtime_load_models (%s) — %s\n",
+                engine_path, runtime_get_error());
+        runtime_cleanup();
         return 1;
     }
-    printf("[OK] runtime_model_loading\n");
+    printf("[OK] runtime_load_models\n");
 
-    /* Send input */
-    tensors_struct *input = make_squeezenet_input();
-    if (send_input(input) != 0) {
-        fprintf(stderr, "FAIL: send_input\n");
-        runtime_destruction();
+    /* Enqueue input */
+    Tensors *input = make_squeezenet_input();
+    if (runtime_enqueue_input(0, input) != RUNTIME_STATUS_SUCCESS) {
+        fprintf(stderr, "FAIL: runtime_enqueue_input — %s\n", runtime_get_error());
+        runtime_cleanup();
         return 1;
     }
-    printf("[OK] send_input\n");
+    printf("[OK] runtime_enqueue_input\n");
 
-    /* Poll for output (up to 10s) */
-    tensors_struct *output = NULL;
-    int attempts = 0;
-    while (receive_output(&output) != 0 && attempts++ < 100)
-        /* sleep 100ms (receive_output already sleeps internally) */;
-
-    if (!output) {
-        fprintf(stderr, "FAIL: receive_output timed out\n");
-        runtime_destruction();
+    /* Retrieve output (block up to 10 seconds) */
+    Tensors *output = NULL;
+    int model_id = -1;
+    RuntimeStatus st = runtime_retrieve_output(&model_id, &output, 10000);
+    if (st != RUNTIME_STATUS_SUCCESS || !output) {
+        fprintf(stderr, "FAIL: runtime_retrieve_output (status=%d) — %s\n",
+                st, runtime_get_error());
+        runtime_cleanup();
         return 1;
     }
-    printf("[OK] receive_output: %zu output tensor(s)\n", output->num_tensors);
+    printf("[OK] runtime_retrieve_output: model_id=%d, %d output tensor(s)\n",
+           model_id, output->num_tensors);
 
-    for (size_t i = 0; i < output->num_tensors; ++i) {
-        printf("  [%zu] name=%s  rank=%zu  shape=[",
-               i, output->names[i], output->ranks[i]);
-        for (size_t d = 0; d < output->ranks[i]; ++d)
-            printf("%s%zu", d ? "," : "", output->shapes[i][d]);
-        printf("]  dtype=%d\n", (int)output->data_types[i]);
+    for (int i = 0; i < output->num_tensors; ++i) {
+        TensorDescriptor *td = &output->tensors[i];
+        printf("  [%d] name=%s  rank=%d  shape=[", i, td->name, td->rank);
+        for (int d = 0; d < td->rank; ++d)
+            printf("%s%d", d ? "," : "", td->shape[d]);
+        printf("]  dtype=%d  data_size=%zu\n", (int)td->data_type, td->data_size);
 
         /* Print first 5 float values */
-        if (output->data_types[i] == DATA_TYPE_FLOAT && output->data[i]) {
-            float *vals = (float *)output->data[i];
+        if (td->data_type == DATA_TYPE_FLOAT && td->data) {
+            float *vals = (float *)td->data;
             printf("  first values: ");
-            for (size_t v = 0; v < 5; ++v) printf("%.4f ", vals[v]);
+            for (int v = 0; v < 5; ++v) printf("%.4f ", vals[v]);
             printf("\n");
         }
     }
 
-    /* Cleanup output (caller owns it) */
-    for (size_t i = 0; i < output->num_tensors; ++i) {
-        free(output->names[i]);
-        free(output->shapes[i]);
-        free(output->data[i]);
+    /* Free output (caller owns it) */
+    for (int i = 0; i < output->num_tensors; ++i) {
+        free(output->tensors[i].name);
+        free(output->tensors[i].shape);
+        free(output->tensors[i].data);
     }
-    free(output->names);
-    free(output->data_types);
-    free(output->ranks);
-    free(output->shapes);
-    free(output->data);
+    free(output->tensors);
     free(output);
 
-    runtime_destruction();
-    printf("[OK] runtime_destruction\n");
+    runtime_cleanup();
+    printf("[OK] runtime_cleanup\n");
     printf("=== PASS ===\n");
     return 0;
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ Converted models are cached — re-running stage1 skips models that already exis
 
 ## Stage 2 — Benchmarking
 
-Benchmarks compiled models using the OAAX runtime library. Requires stage1 to have run first.
+Benchmarks compiled models using the OAAX v2 runtime library. Requires stage1 to have run first.
 
 ```bash
 uv run python -m tests.stage2 --backend trt \

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT DEFINED RUNTIME_INCLUDE_DIR)
     set(RUNTIME_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../tensorrt/runtime-library/include")
 endif()
 
-# tensors_struct.h is bundled in tests/runtime/include/
+# interface.h is bundled in tests/runtime/include/
 set(TESTS_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 message(STATUS "Runtime lib dir:     ${RUNTIME_LIB_DIR}")

--- a/tests/runtime/include/interface.h
+++ b/tests/runtime/include/interface.h
@@ -1,0 +1,104 @@
+#ifndef OAAX_RUNTIME_INTERFACE_H
+#define OAAX_RUNTIME_INTERFACE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum RuntimeStatus {
+  RUNTIME_STATUS_SUCCESS = 0,
+  RUNTIME_STATUS_ERROR = 1,
+  RUNTIME_STATUS_NOT_INITIALIZED = 2,
+  RUNTIME_STATUS_ALREADY_INITIALIZED = 3,
+  RUNTIME_STATUS_MODEL_NOT_LOADED = 4,
+  RUNTIME_STATUS_INVALID_ARGUMENT = 5,
+  RUNTIME_STATUS_INVALID_MODEL = 6,
+  RUNTIME_STATUS_FILE_NOT_FOUND = 7,
+  RUNTIME_STATUS_OUT_OF_MEMORY = 8,
+  RUNTIME_STATUS_INVALID_TENSOR = 9,
+  RUNTIME_STATUS_TENSOR_SHAPE_MISMATCH = 10,
+  RUNTIME_STATUS_TENSOR_TYPE_MISMATCH = 11,
+  RUNTIME_STATUS_NO_OUTPUT_AVAILABLE = 12,
+  RUNTIME_STATUS_INFERENCE_ERROR = 13,
+  RUNTIME_STATUS_NOT_IMPLEMENTED = 14,
+  RUNTIME_STATUS_TIMEOUT = 15,
+  RUNTIME_STATUS_DEVICE_ERROR = 16,
+  RUNTIME_STATUS_UNKNOWN_ERROR = 17,
+  RUNTIME_STATUS_INVALID_MODEL_ID = 18
+} RuntimeStatus;
+
+typedef enum TensorElementType {
+  DATA_TYPE_UNDEFINED = 0,
+  DATA_TYPE_FLOAT = 1,
+  DATA_TYPE_UINT8 = 2,
+  DATA_TYPE_INT8 = 3,
+  DATA_TYPE_UINT16 = 4,
+  DATA_TYPE_INT16 = 5,
+  DATA_TYPE_INT32 = 6,
+  DATA_TYPE_INT64 = 7,
+  DATA_TYPE_STRING = 8,
+  DATA_TYPE_BOOL = 9,
+  DATA_TYPE_FLOAT16 = 10,
+  DATA_TYPE_DOUBLE = 11,
+  DATA_TYPE_UINT32 = 12,
+  DATA_TYPE_UINT64 = 13,
+  DATA_TYPE_COMPLEX64 = 14,
+  DATA_TYPE_COMPLEX128 = 15,
+  DATA_TYPE_BFLOAT16 = 16,
+  DATA_TYPE_FLOAT8E4M3FN = 17,
+  DATA_TYPE_FLOAT8E4M3FNUZ = 18,
+  DATA_TYPE_FLOAT8E5M2 = 19,
+  DATA_TYPE_FLOAT8E5M2FNUZ = 20,
+  DATA_TYPE_UINT4 = 21,
+  DATA_TYPE_INT4 = 22,
+  DATA_TYPE_FLOAT4E2M1 = 23,
+  DATA_TYPE_FLOAT8E8M0 = 24,
+  DATA_TYPE_UINT2 = 25,
+  DATA_TYPE_INT2 = 26
+} TensorElementType;
+
+typedef struct TensorDescriptor {
+  char              *name;
+  TensorElementType  data_type;
+  int                rank;
+  int               *shape;
+  size_t             data_size;
+  void              *data;
+} TensorDescriptor;
+
+typedef struct Tensors {
+  int               id;
+  int               num_tensors;
+  TensorDescriptor *tensors;
+} Tensors;
+
+typedef struct Config {
+  int          length;
+  const char **keys;
+  const char **values;
+} Config;
+
+typedef struct ModelConfig {
+  const char *file_path;
+  const unsigned char *model_data;
+  size_t model_size;
+  Config config;
+} ModelConfig;
+
+RuntimeStatus runtime_init(Config config);
+RuntimeStatus runtime_load_models(int num_models, const ModelConfig *model_configs);
+RuntimeStatus runtime_enqueue_input(int model_id, Tensors *input_tensors);
+RuntimeStatus runtime_retrieve_output(int *model_id, Tensors **output_tensors, int timeout_ms);
+RuntimeStatus runtime_cleanup(void);
+const char *runtime_get_error(void);
+const char *runtime_get_version(void);
+const char *runtime_get_name(void);
+const char *runtime_get_info(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OAAX_RUNTIME_INTERFACE_H

--- a/tests/runtime/include/test_utils.h
+++ b/tests/runtime/include/test_utils.h
@@ -1,0 +1,46 @@
+#ifndef OAAX_TEST_UTILS_H
+#define OAAX_TEST_UTILS_H
+
+#include <cstdlib>
+#include <cstring>
+
+#include "interface.h"
+
+// Allocate a float Tensors with all elements set to 0.5.
+// Caller owns the returned pointer; free with free_tensors().
+static inline Tensors* make_float_input(const char* name, int* shape, int rank, int request_id) {
+    Tensors* ts = (Tensors*)malloc(sizeof(Tensors));
+    ts->id = request_id;
+    ts->num_tensors = 1;
+    ts->tensors = (TensorDescriptor*)malloc(sizeof(TensorDescriptor));
+
+    TensorDescriptor& td = ts->tensors[0];
+    td.name = strdup(name);
+    td.data_type = DATA_TYPE_FLOAT;
+    td.rank = rank;
+    td.shape = (int*)malloc(rank * sizeof(int));
+    size_t n_elems = 1;
+    for (int i = 0; i < rank; i++) {
+        td.shape[i] = shape[i];
+        n_elems *= (size_t)shape[i];
+    }
+    td.data_size = n_elems * sizeof(float);
+    float* buf = (float*)malloc(td.data_size);
+    for (size_t i = 0; i < n_elems; i++) buf[i] = 0.5f;
+    td.data = buf;
+    return ts;
+}
+
+// Free a Tensors allocated by make_float_input or returned by runtime_retrieve_output.
+static inline void free_tensors(Tensors* ts) {
+    if (!ts) return;
+    for (int i = 0; i < ts->num_tensors; i++) {
+        free(ts->tensors[i].name);
+        free(ts->tensors[i].shape);
+        free(ts->tensors[i].data);
+    }
+    free(ts->tensors);
+    free(ts);
+}
+
+#endif // OAAX_TEST_UTILS_H

--- a/tests/runtime/inference_test.cpp
+++ b/tests/runtime/inference_test.cpp
@@ -1,21 +1,16 @@
 /**
  * NVIDIA OAAX v2 runtime benchmark.
  *
- * Runs sequential inference (enqueue → retrieve → measure latency) and
- * reports avg / min / max / p95 latency and throughput.
- *
- * Usage:
- *   ./inference_test <model.trt|model.onnx> [options]
+ * Usage: ./inference_test <model.trt|model.onnx> [options]
  *
  * Options:
  *   --input-name  NAME     tensor name (default: input)
  *   --input-shape N,N,...  comma-separated dims (default: 1,3,640,640)
  *   --runs        N        benchmark iterations (default: 100)
  *   --warmup      N        warmup iterations (default: 10)
- *   --log-level   N        0=trace … 4=err (default: 3)
+ *   --log-level   N        0=trace ... 4=err (default: 3)
  *   --no-validate          skip output tensor sanity check
  */
-
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
@@ -25,9 +20,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
-
 #include "interface.h"
-#include "test_utils.h"
 
 using Clock = std::chrono::steady_clock;
 using Ms    = std::chrono::duration<double, std::milli>;
@@ -35,19 +28,36 @@ using Ms    = std::chrono::duration<double, std::milli>;
 #define CHECK(cond, msg) \
     do { if (!(cond)) { std::cerr << "FAIL: " << (msg) << std::endl; runtime_cleanup(); return 1; } } while (0)
 
-// Wrap make_float_input for vector<int> shape
 static Tensors* make_input(const char* name, const std::vector<int>& shape, int request_id) {
-    return make_float_input(name, const_cast<int*>(shape.data()), (int)shape.size(), request_id);
+    Tensors* ts = (Tensors*)malloc(sizeof(Tensors));
+    ts->id = request_id;
+    ts->num_tensors = 1;
+    ts->tensors = (TensorDescriptor*)malloc(sizeof(TensorDescriptor));
+    TensorDescriptor& td = ts->tensors[0];
+    td.name = strdup(name);
+    td.data_type = DATA_TYPE_FLOAT;
+    td.rank = (int)shape.size();
+    td.shape = (int*)malloc(shape.size() * sizeof(int));
+    size_t n_elems = 1;
+    for (size_t i = 0; i < shape.size(); i++) { td.shape[i] = shape[i]; n_elems *= (size_t)shape[i]; }
+    td.data_size = n_elems * sizeof(float);
+    float* buf = (float*)malloc(td.data_size);
+    for (size_t i = 0; i < n_elems; i++) buf[i] = 0.5f;
+    td.data = buf;
+    return ts;
 }
 
-// Poll with a per-call timeout until success or max_polls exhausted
+static void free_tensors(Tensors* ts) {
+    if (!ts) return;
+    for (int i = 0; i < ts->num_tensors; i++) { free(ts->tensors[i].name); free(ts->tensors[i].shape); free(ts->tensors[i].data); }
+    free(ts->tensors); free(ts);
+}
+
 static Tensors* poll_output(int timeout_per_poll_ms = 50, int max_polls = 200) {
     Tensors* out = nullptr;
     int model_id = -1;
-    for (int i = 0; i < max_polls; i++) {
-        if (runtime_retrieve_output(&model_id, &out, timeout_per_poll_ms) == RUNTIME_STATUS_SUCCESS)
-            return out;
-    }
+    for (int i = 0; i < max_polls; i++)
+        if (runtime_retrieve_output(&model_id, &out, timeout_per_poll_ms) == RUNTIME_STATUS_SUCCESS) return out;
     return nullptr;
 }
 
@@ -58,34 +68,21 @@ static double percentile(std::vector<double> v, double p) {
 }
 
 static std::vector<int> parse_shape(const std::string& s) {
-    std::vector<int> dims;
-    std::istringstream ss(s);
-    std::string tok;
-    while (std::getline(ss, tok, ','))
-        dims.push_back(std::stoi(tok));
+    std::vector<int> dims; std::istringstream ss(s); std::string tok;
+    while (std::getline(ss, tok, ',')) dims.push_back(std::stoi(tok));
     return dims;
 }
 
 int main(int argc, char** argv) {
     if (argc < 2) {
         std::cerr << "Usage: " << argv[0] << " <model.trt|model.onnx> [options]\n"
-                  << "  --input-name  NAME\n"
-                  << "  --input-shape N,N,...  (default: 1,3,640,640)\n"
-                  << "  --runs        N        (default: 100)\n"
-                  << "  --warmup      N        (default: 10)\n"
-                  << "  --log-level   N        (default: 3)\n"
-                  << "  --no-validate\n";
+                  << "  --input-name NAME  --input-shape N,N,...  --runs N  --warmup N  --log-level N  --no-validate\n";
         return 1;
     }
-
     const char* model_path = argv[1];
-    std::string input_name = "input";
-    std::string shape_str  = "1,3,640,640";
-    int runs      = 100;
-    int warmup    = 10;
-    int log_level = 3;
+    std::string input_name = "input", shape_str = "1,3,640,640";
+    int runs = 100, warmup = 10, log_level = 3;
     bool validate = true;
-
     for (int i = 2; i < argc; i++) {
         if      (strcmp(argv[i], "--input-name")  == 0 && i+1 < argc) input_name = argv[++i];
         else if (strcmp(argv[i], "--input-shape") == 0 && i+1 < argc) shape_str  = argv[++i];
@@ -94,16 +91,12 @@ int main(int argc, char** argv) {
         else if (strcmp(argv[i], "--log-level")   == 0 && i+1 < argc) log_level  = atoi(argv[++i]);
         else if (strcmp(argv[i], "--no-validate") == 0)               validate   = false;
     }
-
     auto shape = parse_shape(shape_str);
 
     std::cout << "=== NVIDIA OAAX v2 Inference Benchmark ===" << std::endl;
-    std::cout << "Model      : " << model_path << std::endl;
-    std::cout << "Input      : " << input_name << " [" << shape_str << "]" << std::endl;
-    std::cout << "Warmup     : " << warmup << " runs" << std::endl;
-    std::cout << "Runs       : " << runs << std::endl << std::endl;
+    std::cout << "Model: " << model_path << "  Input: " << input_name << " [" << shape_str << "]" << std::endl;
+    std::cout << "Warmup: " << warmup << "  Runs: " << runs << std::endl << std::endl;
 
-    // Init
     std::cout << "[1] Initializing runtime..." << std::endl;
     std::string ll_str = std::to_string(log_level);
     const char* keys[]   = {"log_level"};
@@ -112,7 +105,6 @@ int main(int argc, char** argv) {
     CHECK(runtime_init(cfg) == RUNTIME_STATUS_SUCCESS, "runtime_init failed");
     std::cout << "  " << runtime_get_name() << " v" << runtime_get_version() << std::endl;
 
-    // Load
     std::cout << "[2] Loading model..." << std::endl;
     auto t_load = Clock::now();
     ModelConfig mc{model_path, nullptr, 0, {0, nullptr, nullptr}};
@@ -121,7 +113,6 @@ int main(int argc, char** argv) {
     double load_ms = Ms(Clock::now() - t_load).count();
     std::cout << "  Loaded in " << load_ms << " ms" << std::endl;
 
-    // Warmup
     std::cout << "[3] Warming up (" << warmup << " runs)..." << std::endl;
     for (int i = 0; i < warmup; i++) {
         Tensors* inp = make_input(input_name.c_str(), shape, i);
@@ -132,40 +123,32 @@ int main(int argc, char** argv) {
     }
     std::cout << "  Done" << std::endl;
 
-    // Benchmark
     std::cout << "[4] Benchmarking (" << runs << " runs)..." << std::endl;
     std::vector<double> latencies(runs);
     auto bench_start = Clock::now();
-
     for (int i = 0; i < runs; i++) {
         Tensors* inp = make_input(input_name.c_str(), shape, i);
         auto t0 = Clock::now();
-        CHECK(runtime_enqueue_input(0, inp) == RUNTIME_STATUS_SUCCESS, "runtime_enqueue_input failed during benchmark");
+        CHECK(runtime_enqueue_input(0, inp) == RUNTIME_STATUS_SUCCESS, "runtime_enqueue_input failed");
         Tensors* out = poll_output();
-        CHECK(out != nullptr, "runtime_retrieve_output timed out during benchmark");
+        CHECK(out != nullptr, "runtime_retrieve_output timed out");
         latencies[i] = Ms(Clock::now() - t0).count();
-
-        if (validate && i == 0)
-            CHECK(out->num_tensors > 0, "output has no tensors");
+        if (validate && i == 0) CHECK(out->num_tensors > 0, "output has no tensors");
         free_tensors(out);
     }
-
     double bench_ms = Ms(Clock::now() - bench_start).count();
     double avg = std::accumulate(latencies.begin(), latencies.end(), 0.0) / latencies.size();
     double mn  = *std::min_element(latencies.begin(), latencies.end());
     double mx  = *std::max_element(latencies.begin(), latencies.end());
     double p95 = percentile(latencies, 95.0);
-    double fps = runs * 1000.0 / bench_ms;
-
     std::cout << "\n=== Results ===" << std::endl;
     std::cout << "  Load time  : " << load_ms << " ms" << std::endl;
     std::cout << "  Avg latency: " << avg << " ms" << std::endl;
     std::cout << "  Min latency: " << mn  << " ms" << std::endl;
     std::cout << "  Max latency: " << mx  << " ms" << std::endl;
     std::cout << "  p95 latency: " << p95 << " ms" << std::endl;
-    std::cout << "  Throughput : " << fps << " img/s" << std::endl;
+    std::cout << "  Throughput : " << runs * 1000.0 / bench_ms << " img/s" << std::endl;
 
-    // Cleanup
     std::cout << "\n[5] Cleaning up..." << std::endl;
     CHECK(runtime_cleanup() == RUNTIME_STATUS_SUCCESS, "runtime_cleanup failed");
     std::cout << "  Done" << std::endl;

--- a/tests/runtime/inference_test.cpp
+++ b/tests/runtime/inference_test.cpp
@@ -1,11 +1,11 @@
 /**
- * NVIDIA OAAX v1 runtime benchmark.
+ * NVIDIA OAAX v2 runtime benchmark.
  *
- * Runs sequential inference (send → poll receive → measure latency) and
+ * Runs sequential inference (enqueue → retrieve → measure latency) and
  * reports avg / min / max / p95 latency and throughput.
  *
  * Usage:
- *   ./inference_test <model.trt> [options]
+ *   ./inference_test <model.trt|model.onnx> [options]
  *
  * Options:
  *   --input-name  NAME     tensor name (default: input)
@@ -24,80 +24,29 @@
 #include <numeric>
 #include <sstream>
 #include <string>
-#include <thread>
 #include <vector>
 
-extern "C" {
-#include "tensors_struct.h"
-}
-
-extern "C" {
-    int  runtime_initialization();
-    int  runtime_initialization_with_args(int length, char** keys, void** values);
-    int  runtime_model_loading(const char* path);
-    int  send_input(tensors_struct* input);
-    int  receive_output(tensors_struct** output);
-    int  runtime_destruction();
-    const char* runtime_error_message();
-    const char* runtime_version();
-    const char* runtime_name();
-}
+#include "interface.h"
+#include "test_utils.h"
 
 using Clock = std::chrono::steady_clock;
 using Ms    = std::chrono::duration<double, std::milli>;
 
 #define CHECK(cond, msg) \
-    do { if (!(cond)) { std::cerr << "FAIL: " << (msg) << std::endl; runtime_destruction(); return 1; } } while (0)
+    do { if (!(cond)) { std::cerr << "FAIL: " << (msg) << std::endl; runtime_cleanup(); return 1; } } while (0)
 
-static tensors_struct* make_input(const char* name, const std::vector<size_t>& shape) {
-    tensors_struct* ts = (tensors_struct*)malloc(sizeof(tensors_struct));
-    ts->num_tensors = 1;
-
-    ts->names = (char**)malloc(sizeof(char*));
-    ts->names[0] = strdup(name);
-
-    ts->data_types = (tensor_data_type*)malloc(sizeof(tensor_data_type));
-    ts->data_types[0] = DATA_TYPE_FLOAT;
-
-    ts->ranks = (size_t*)malloc(sizeof(size_t));
-    ts->ranks[0] = shape.size();
-
-    ts->shapes = (size_t**)malloc(sizeof(size_t*));
-    ts->shapes[0] = (size_t*)malloc(shape.size() * sizeof(size_t));
-    size_t n_elems = 1;
-    for (size_t i = 0; i < shape.size(); i++) {
-        ts->shapes[0][i] = shape[i];
-        n_elems *= shape[i];
-    }
-
-    ts->data = (void**)malloc(sizeof(void*));
-    float* buf = (float*)calloc(n_elems, sizeof(float));
-    for (size_t i = 0; i < n_elems; i++) buf[i] = 0.5f;
-    ts->data[0] = buf;
-
-    return ts;
+// Wrap make_float_input for vector<int> shape
+static Tensors* make_input(const char* name, const std::vector<int>& shape, int request_id) {
+    return make_float_input(name, const_cast<int*>(shape.data()), (int)shape.size(), request_id);
 }
 
-static void free_tensors(tensors_struct* ts) {
-    if (!ts) return;
-    for (size_t i = 0; i < ts->num_tensors; i++) {
-        free(ts->names[i]);
-        free(ts->shapes[i]);
-        free(ts->data[i]);
-    }
-    free(ts->names);
-    free(ts->data_types);
-    free(ts->ranks);
-    free(ts->shapes);
-    free(ts->data);
-    free(ts);
-}
-
-static tensors_struct* poll_output(int max_polls = 500) {
-    tensors_struct* out = nullptr;
+// Poll with a per-call timeout until success or max_polls exhausted
+static Tensors* poll_output(int timeout_per_poll_ms = 50, int max_polls = 200) {
+    Tensors* out = nullptr;
+    int model_id = -1;
     for (int i = 0; i < max_polls; i++) {
-        if (receive_output(&out) == 0) return out;
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        if (runtime_retrieve_output(&model_id, &out, timeout_per_poll_ms) == RUNTIME_STATUS_SUCCESS)
+            return out;
     }
     return nullptr;
 }
@@ -108,18 +57,18 @@ static double percentile(std::vector<double> v, double p) {
     return v[std::min(idx, v.size() - 1)];
 }
 
-static std::vector<size_t> parse_shape(const std::string& s) {
-    std::vector<size_t> dims;
+static std::vector<int> parse_shape(const std::string& s) {
+    std::vector<int> dims;
     std::istringstream ss(s);
     std::string tok;
     while (std::getline(ss, tok, ','))
-        dims.push_back((size_t)std::stoul(tok));
+        dims.push_back(std::stoi(tok));
     return dims;
 }
 
 int main(int argc, char** argv) {
     if (argc < 2) {
-        std::cerr << "Usage: " << argv[0] << " <model.trt> [options]\n"
+        std::cerr << "Usage: " << argv[0] << " <model.trt|model.onnx> [options]\n"
                   << "  --input-name  NAME\n"
                   << "  --input-shape N,N,...  (default: 1,3,640,640)\n"
                   << "  --runs        N        (default: 100)\n"
@@ -130,12 +79,12 @@ int main(int argc, char** argv) {
     }
 
     const char* model_path = argv[1];
-    std::string input_name  = "input";
-    std::string shape_str   = "1,3,640,640";
-    int runs       = 100;
-    int warmup     = 10;
-    int log_level  = 3;
-    bool validate  = true;
+    std::string input_name = "input";
+    std::string shape_str  = "1,3,640,640";
+    int runs      = 100;
+    int warmup    = 10;
+    int log_level = 3;
+    bool validate = true;
 
     for (int i = 2; i < argc; i++) {
         if      (strcmp(argv[i], "--input-name")  == 0 && i+1 < argc) input_name = argv[++i];
@@ -148,7 +97,7 @@ int main(int argc, char** argv) {
 
     auto shape = parse_shape(shape_str);
 
-    std::cout << "=== NVIDIA OAAX Inference Benchmark ===" << std::endl;
+    std::cout << "=== NVIDIA OAAX v2 Inference Benchmark ===" << std::endl;
     std::cout << "Model      : " << model_path << std::endl;
     std::cout << "Input      : " << input_name << " [" << shape_str << "]" << std::endl;
     std::cout << "Warmup     : " << warmup << " runs" << std::endl;
@@ -157,26 +106,28 @@ int main(int argc, char** argv) {
     // Init
     std::cout << "[1] Initializing runtime..." << std::endl;
     std::string ll_str = std::to_string(log_level);
-    char* keys[]   = {(char*)"log_level"};
-    void* values[] = {(void*)ll_str.c_str()};
-    CHECK(runtime_initialization_with_args(1, keys, values) == 0, "runtime_initialization_with_args failed");
-    std::cout << "  " << runtime_name() << " v" << runtime_version() << std::endl;
+    const char* keys[]   = {"log_level"};
+    const char* values[] = {ll_str.c_str()};
+    Config cfg{1, keys, values};
+    CHECK(runtime_init(cfg) == RUNTIME_STATUS_SUCCESS, "runtime_init failed");
+    std::cout << "  " << runtime_get_name() << " v" << runtime_get_version() << std::endl;
 
     // Load
     std::cout << "[2] Loading model..." << std::endl;
     auto t_load = Clock::now();
-    CHECK(runtime_model_loading(model_path) == 0,
-          std::string("runtime_model_loading failed: ") + (runtime_error_message() ? runtime_error_message() : ""));
+    ModelConfig mc{model_path, nullptr, 0, {0, nullptr, nullptr}};
+    CHECK(runtime_load_models(1, &mc) == RUNTIME_STATUS_SUCCESS,
+          std::string("runtime_load_models failed: ") + (runtime_get_error() ? runtime_get_error() : ""));
     double load_ms = Ms(Clock::now() - t_load).count();
     std::cout << "  Loaded in " << load_ms << " ms" << std::endl;
 
     // Warmup
     std::cout << "[3] Warming up (" << warmup << " runs)..." << std::endl;
     for (int i = 0; i < warmup; i++) {
-        tensors_struct* inp = make_input(input_name.c_str(), shape);
-        CHECK(send_input(inp) == 0, "send_input failed during warmup");
-        tensors_struct* out = poll_output();
-        CHECK(out != nullptr, "receive_output timed out during warmup");
+        Tensors* inp = make_input(input_name.c_str(), shape, i);
+        CHECK(runtime_enqueue_input(0, inp) == RUNTIME_STATUS_SUCCESS, "runtime_enqueue_input failed during warmup");
+        Tensors* out = poll_output();
+        CHECK(out != nullptr, "runtime_retrieve_output timed out during warmup");
         free_tensors(out);
     }
     std::cout << "  Done" << std::endl;
@@ -187,16 +138,15 @@ int main(int argc, char** argv) {
     auto bench_start = Clock::now();
 
     for (int i = 0; i < runs; i++) {
-        tensors_struct* inp = make_input(input_name.c_str(), shape);
+        Tensors* inp = make_input(input_name.c_str(), shape, i);
         auto t0 = Clock::now();
-        CHECK(send_input(inp) == 0, "send_input failed during benchmark");
-        tensors_struct* out = poll_output();
-        CHECK(out != nullptr, "receive_output timed out during benchmark");
+        CHECK(runtime_enqueue_input(0, inp) == RUNTIME_STATUS_SUCCESS, "runtime_enqueue_input failed during benchmark");
+        Tensors* out = poll_output();
+        CHECK(out != nullptr, "runtime_retrieve_output timed out during benchmark");
         latencies[i] = Ms(Clock::now() - t0).count();
 
-        if (validate && i == 0) {
+        if (validate && i == 0)
             CHECK(out->num_tensors > 0, "output has no tensors");
-        }
         free_tensors(out);
     }
 
@@ -217,8 +167,7 @@ int main(int argc, char** argv) {
 
     // Cleanup
     std::cout << "\n[5] Cleaning up..." << std::endl;
-    CHECK(runtime_destruction() == 0, "runtime_destruction failed");
+    CHECK(runtime_cleanup() == RUNTIME_STATUS_SUCCESS, "runtime_cleanup failed");
     std::cout << "  Done" << std::endl;
-
     return 0;
 }

--- a/tests/runtime/simple_test.cpp
+++ b/tests/runtime/simple_test.cpp
@@ -1,148 +1,104 @@
 /**
- * Smoke test for the NVIDIA OAAX v1 runtime API.
+ * Smoke test for the NVIDIA OAAX v2 runtime API.
  *
- * Verifies:
- * 1. runtime_initialization() succeeds
- * 2. runtime_name() / runtime_version() return non-empty strings
- * 3. runtime_model_loading() fails gracefully for a non-existent path
- * 4. runtime_error_message() is set after failure
- * 5. Model loading + round-trip inference (optional, pass .trt path as arg)
- * 6. runtime_destruction() is idempotent
- *
- * Usage:
- *   ./simple_test [model.trt]
+ * Usage: ./simple_test [model.trt|model.onnx]
  */
-
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
-#include <thread>
-#include <chrono>
-
-extern "C" {
-#include "tensors_struct.h"
-}
-
-extern "C" {
-    int  runtime_initialization();
-    int  runtime_model_loading(const char* path);
-    int  send_input(tensors_struct* input);
-    int  receive_output(tensors_struct** output);
-    int  runtime_destruction();
-    const char* runtime_error_message();
-    const char* runtime_version();
-    const char* runtime_name();
-}
+#include "interface.h"
 
 #define PASS(msg)  std::cout << "  PASS: " << (msg) << std::endl
-#define FAIL(msg)  do { std::cerr << "  FAIL: " << (msg) << std::endl; runtime_destruction(); return 1; } while (0)
+#define FAIL(msg)  do { std::cerr << "  FAIL: " << (msg) << std::endl; runtime_cleanup(); return 1; } while (0)
 #define ASSERT(cond, msg) do { if (!(cond)) FAIL(msg); } while (0)
 
-static tensors_struct* make_float_input(const char* name, size_t* shape, size_t rank) {
-    tensors_struct* ts = (tensors_struct*)malloc(sizeof(tensors_struct));
+static Tensors* make_float_input(const char* name, int* shape, int rank, int request_id) {
+    Tensors* ts = (Tensors*)malloc(sizeof(Tensors));
+    ts->id = request_id;
     ts->num_tensors = 1;
-
-    ts->names = (char**)malloc(sizeof(char*));
-    ts->names[0] = strdup(name);
-
-    ts->data_types = (tensor_data_type*)malloc(sizeof(tensor_data_type));
-    ts->data_types[0] = DATA_TYPE_FLOAT;
-
-    ts->ranks = (size_t*)malloc(sizeof(size_t));
-    ts->ranks[0] = rank;
-
-    ts->shapes = (size_t**)malloc(sizeof(size_t*));
-    ts->shapes[0] = (size_t*)malloc(rank * sizeof(size_t));
+    ts->tensors = (TensorDescriptor*)malloc(sizeof(TensorDescriptor));
+    TensorDescriptor& td = ts->tensors[0];
+    td.name = strdup(name);
+    td.data_type = DATA_TYPE_FLOAT;
+    td.rank = rank;
+    td.shape = (int*)malloc(rank * sizeof(int));
     size_t n_elems = 1;
-    for (size_t i = 0; i < rank; i++) {
-        ts->shapes[0][i] = shape[i];
-        n_elems *= shape[i];
-    }
-
-    ts->data = (void**)malloc(sizeof(void*));
-    float* buf = (float*)calloc(n_elems, sizeof(float));
+    for (int i = 0; i < rank; i++) { td.shape[i] = shape[i]; n_elems *= (size_t)shape[i]; }
+    td.data_size = n_elems * sizeof(float);
+    float* buf = (float*)malloc(td.data_size);
     for (size_t i = 0; i < n_elems; i++) buf[i] = 0.5f;
-    ts->data[0] = buf;
-
+    td.data = buf;
     return ts;
 }
 
-static void free_tensors(tensors_struct* ts) {
+static void free_tensors(Tensors* ts) {
     if (!ts) return;
-    for (size_t i = 0; i < ts->num_tensors; i++) {
-        free(ts->names[i]);
-        free(ts->shapes[i]);
-        free(ts->data[i]);
-    }
-    free(ts->names);
-    free(ts->data_types);
-    free(ts->ranks);
-    free(ts->shapes);
-    free(ts->data);
-    free(ts);
+    for (int i = 0; i < ts->num_tensors; i++) { free(ts->tensors[i].name); free(ts->tensors[i].shape); free(ts->tensors[i].data); }
+    free(ts->tensors); free(ts);
 }
 
 int main(int argc, char** argv) {
-    std::cout << "=== NVIDIA OAAX v1 Runtime Smoke Test ===" << std::endl;
+    std::cout << "=== NVIDIA OAAX v2 Runtime Smoke Test ===" << std::endl;
 
-    // 1. Init
-    std::cout << "\n[1] runtime_initialization()" << std::endl;
-    ASSERT(runtime_initialization() == 0, "runtime_initialization failed");
+    std::cout << "\n[1] runtime_init()" << std::endl;
+    Config cfg{0, nullptr, nullptr};
+    ASSERT(runtime_init(cfg) == RUNTIME_STATUS_SUCCESS, "runtime_init failed");
     PASS("runtime initialized");
 
-    // 2. Version / name
-    std::cout << "\n[2] runtime_name() / runtime_version()" << std::endl;
-    const char* name = runtime_name();
-    const char* ver  = runtime_version();
+    std::cout << "\n[2] runtime_get_name() / runtime_get_version()" << std::endl;
+    const char* name = runtime_get_name();
+    const char* ver  = runtime_get_version();
     ASSERT(name && strlen(name) > 0, "name is empty");
     ASSERT(ver  && strlen(ver)  > 0, "version is empty");
     std::cout << "  name: " << name << "  version: " << ver << std::endl;
     PASS("name and version returned");
 
-    // 3. Load non-existent model
-    std::cout << "\n[3] runtime_model_loading() with bad path" << std::endl;
-    ASSERT(runtime_model_loading("/nonexistent/path/model.trt") != 0, "load should fail for bad path");
-    const char* err = runtime_error_message();
-    ASSERT(err && strlen(err) > 0, "runtime_error_message() should be set after failure");
+    std::cout << "\n[3] runtime_get_info()" << std::endl;
+    const char* info = runtime_get_info();
+    if (info) std::cout << "  info: " << info << std::endl;
+    PASS("runtime_get_info did not crash");
+
+    std::cout << "\n[4] runtime_load_models() with bad path" << std::endl;
+    ModelConfig bad_mc{"/nonexistent/path/model.trt", nullptr, 0, {0, nullptr, nullptr}};
+    ASSERT(runtime_load_models(1, &bad_mc) != RUNTIME_STATUS_SUCCESS, "load should fail for bad path");
+    const char* err = runtime_get_error();
+    ASSERT(err && strlen(err) > 0, "runtime_get_error() should be set after failure");
     std::cout << "  error: " << err << std::endl;
     PASS("bad-path load failed with error message");
 
-    // 4. Optional: load real model and run inference
     if (argc > 1) {
-        std::cout << "\n[4] runtime_model_loading(): " << argv[1] << std::endl;
-
-        // Re-init after failed load
-        runtime_destruction();
-        ASSERT(runtime_initialization() == 0, "re-init failed");
-
-        ASSERT(runtime_model_loading(argv[1]) == 0,
-               std::string("model load failed: ") + (runtime_error_message() ? runtime_error_message() : ""));
+        std::cout << "\n[5] runtime_load_models(): " << argv[1] << std::endl;
+        ModelConfig mc{argv[1], nullptr, 0, {0, nullptr, nullptr}};
+        ASSERT(runtime_load_models(1, &mc) == RUNTIME_STATUS_SUCCESS,
+               std::string("model load failed: ") + (runtime_get_error() ? runtime_get_error() : ""));
         PASS("model loaded");
 
-        std::cout << "\n[5] send_input() + receive_output()" << std::endl;
-        size_t shape[] = {1, 4};
-        tensors_struct* input = make_float_input("input", shape, 2);
-        ASSERT(send_input(input) == 0, "send_input failed");
-        PASS("send_input accepted");
+        std::cout << "\n[6] runtime_enqueue_input() + runtime_retrieve_output()" << std::endl;
+        int shape[] = {1, 4};
+        Tensors* input = make_float_input("input", shape, 2, 42);
+        ASSERT(runtime_enqueue_input(0, input) == RUNTIME_STATUS_SUCCESS, "runtime_enqueue_input failed");
+        PASS("runtime_enqueue_input accepted");
 
-        tensors_struct* output = nullptr;
-        int poll = 0;
-        while (receive_output(&output) != 0 && poll++ < 200) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        }
-        ASSERT(output != nullptr, "receive_output timed out after 200 polls");
-        std::cout << "  output: " << output->num_tensors << " tensor(s), polled " << poll << " times" << std::endl;
+        Tensors* output = nullptr;
+        int out_model_id = -1;
+        RuntimeStatus status = RUNTIME_STATUS_NO_OUTPUT_AVAILABLE;
+        for (int poll = 0; poll < 200 && status != RUNTIME_STATUS_SUCCESS; poll++)
+            status = runtime_retrieve_output(&out_model_id, &output, 50);
+        ASSERT(status == RUNTIME_STATUS_SUCCESS, "runtime_retrieve_output timed out");
+        ASSERT(output != nullptr, "output is null");
+        ASSERT(out_model_id == 0, "model_id mismatch");
+        std::cout << "  output: " << output->num_tensors << " tensor(s), model_id=" << out_model_id << std::endl;
         free_tensors(output);
         PASS("round-trip inference OK");
     } else {
-        std::cout << "\n[4] Skipping model load (no path provided)" << std::endl;
-        std::cout << "    Usage: " << argv[0] << " <model.trt>" << std::endl;
+        std::cout << "\n[5] Skipping model load (no path provided)" << std::endl;
+        std::cout << "    Usage: " << argv[0] << " <model.trt|model.onnx>" << std::endl;
     }
 
-    // 6. Cleanup (idempotent)
-    std::cout << "\n[6] runtime_destruction()" << std::endl;
-    ASSERT(runtime_destruction() == 0, "runtime_destruction failed");
-    ASSERT(runtime_destruction() == 0, "second runtime_destruction should succeed (idempotent)");
-    PASS("destruction OK (idempotent)");
+    std::cout << "\n[7] runtime_cleanup()" << std::endl;
+    ASSERT(runtime_cleanup() == RUNTIME_STATUS_SUCCESS, "runtime_cleanup failed");
+    ASSERT(runtime_cleanup() == RUNTIME_STATUS_SUCCESS, "second runtime_cleanup should succeed (idempotent)");
+    PASS("cleanup OK (idempotent)");
 
     std::cout << "\n=== All tests passed ===" << std::endl;
     return 0;


### PR DESCRIPTION
## Summary

- Implements the OAAX v2 C API for the OnnxRuntime backend
- Replaces old tensors_struct SoA layout and int return codes with new `Tensors` AoS layout and `RuntimeStatus` enum
- Adds multi-model support, timeout-aware `runtime_retrieve_output`, and `runtime_get_info()`

## Changes

- Added `onnxruntime/runtime-library/include/interface.h` with the full OAAX v2 C API definitions (`RuntimeStatus`, `TensorElementType`, `TensorDescriptor`, `Tensors`, `Config`, `ModelConfig`, and all function declarations)
- Rewrote `runtime_core.hpp` to expose all v2 API functions with proper visibility attributes
- Rewrote `runtime_utils.hpp` to match new type signatures
- Rewrote `runtime_core.cpp` with per-model inference threads, a shared output queue, and timeout-aware retrieval
- Rewrote `runtime_utils.cpp` with updated type mapping and memory management helpers

## Test plan

- [ ] Build the shared library with `build-runtimes.sh` and verify no compile errors
- [ ] Load a model via `runtime_load_models` with a file path and confirm successful initialization
- [ ] Run an inference with `runtime_enqueue_input` / `runtime_retrieve_output` and verify output tensors
- [ ] Test `runtime_get_info()` returns valid JSON after loading models
- [ ] Test `runtime_cleanup()` releases all resources without leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)